### PR TITLE
chore: add travis and goreleaser config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.python-version
 .idea/
 .antlr/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
 .antlr/
+dist/
 
 modelicafmt

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,72 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    - go mod download
+builds:
+- env:
+  - CGO_ENABLED=0
+  goos:
+  - darwin
+  - linux
+  - windows
+  goarch:
+  - amd64
+archives:
+- replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
+# TODO: add release config
+# release:
+#   # Repo in which the release will be created.
+#   # Default is extracted from the origin remote URL or empty if its private hosted.
+#   # Note: it can only be one: either github or gitlab or gitea
+#   github:
+#     owner: user
+#     name: repo
+
+#   # IDs of the archives to use.
+#   # Defaults to all.
+#   ids:
+#     - foo
+#     - bar
+
+#   # If set to true, will not auto-publish the release.
+#   # Default is false.
+#   draft: true
+
+#   # If set to auto, will mark the release as not ready for production
+#   # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
+#   # If set to true, will mark the release as not ready for production.
+#   # Default is false.
+#   prerelease: auto
+
+#   # You can change the name of the GitHub release.
+#   # Default is `{{.Tag}}`
+#   name_template: "{{.ProjectName}}-v{{.Version}} {{.Env.USER}}"
+
+#   # You can disable this pipe in order to not upload any artifacts to
+#   # GitHub.
+#   # Defaults to false.
+#   disable: true
+
+#   # You can add extra pre-existing files to the release.
+#   # The filename on the release will be the last part of the path (base). If
+#   # another file with the same name exists, the latest one found will be used.
+#   # Defaults to empty.
+#   extra_files:
+#     - glob: ./path/to/file.txt
+#     - glob: ./glob/**/to/**/file/**/*
+#     - glob: ./glob/foo/to/bar/file/foobar/override_from_previous

--- a/.travis.yaml
+++ b/.travis.yaml
@@ -1,0 +1,14 @@
+language: go
+
+script:
+  - go test ./...
+  - curl -sfL https://git.io/goreleaser | sh -s -- check
+
+# calls goreleaser
+deploy:
+- provider: script
+  skip_cleanup: true
+  script: curl -sL https://git.io/goreleaser | bash
+  on:
+    tags: true
+    condition: $TRAVIS_OS_NAME = linux

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2020, Alliance for Sustainable Energy, LLC, and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions
+and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+and the following disclaimer in the documentation and/or other materials provided with the
+distribution.
+
+Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/generate_parser.sh
+++ b/generate_parser.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 docker build -t antlr4:latest -f thirdparty/Dockerfile-Antlr .
 

--- a/main.go
+++ b/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, Alliance for Sustainable Energy, LLC.
+// All rights reserved.
+
 // Package main runs the formatter
 package main
 

--- a/modelicafmt.go
+++ b/modelicafmt.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, Alliance for Sustainable Energy, LLC.
+// All rights reserved.
+
 package main
 
 import (


### PR DESCRIPTION
### Additions
- add travis config file for running goreleaser
- add goreleaser config file for building darwin, linux, and windows with amd64 arch
- remove i386 arch because of an int overflow due to Antlr's generated code (see https://github.com/antlr/antlr4/issues/2433)
