### PR TITLE
Fix/travis config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,10 +1,11 @@
-# This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
 before:
   hooks:
     - go mod download
 builds:
-- env:
+-
+  binary: modelicafmt
+  env:
   - CGO_ENABLED=0
   goos:
   - darwin
@@ -28,45 +29,9 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
-# TODO: add release config
-# release:
-#   # Repo in which the release will be created.
-#   # Default is extracted from the origin remote URL or empty if its private hosted.
-#   # Note: it can only be one: either github or gitlab or gitea
-#   github:
-#     owner: user
-#     name: repo
-
-#   # IDs of the archives to use.
-#   # Defaults to all.
-#   ids:
-#     - foo
-#     - bar
-
-#   # If set to true, will not auto-publish the release.
-#   # Default is false.
-#   draft: true
-
-#   # If set to auto, will mark the release as not ready for production
-#   # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
-#   # If set to true, will mark the release as not ready for production.
-#   # Default is false.
-#   prerelease: auto
-
-#   # You can change the name of the GitHub release.
-#   # Default is `{{.Tag}}`
-#   name_template: "{{.ProjectName}}-v{{.Version}} {{.Env.USER}}"
-
-#   # You can disable this pipe in order to not upload any artifacts to
-#   # GitHub.
-#   # Defaults to false.
-#   disable: true
-
-#   # You can add extra pre-existing files to the release.
-#   # The filename on the release will be the last part of the path (base). If
-#   # another file with the same name exists, the latest one found will be used.
-#   # Defaults to empty.
-#   extra_files:
-#     - glob: ./path/to/file.txt
-#     - glob: ./glob/**/to/**/file/**/*
-#     - glob: ./glob/foo/to/bar/file/foobar/override_from_previous
+release:
+  # If set to auto, will mark the release as not ready for production
+  # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
+  # If set to true, will mark the release as not ready for production.
+  # Default is false.
+  prerelease: auto

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+env:
+  # goreleaser requires go mod
+  - GO111MODULE=on
+
 script:
   - go test ./...
   - curl -sfL https://git.io/goreleaser | sh -s -- check

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Modelica Formatter provides the ability to automatically format Modelica cod
 ## Running
 
 ```bash
-modelica-fmt [-w] [-p] [-help] <sources>...
+modelicafmt [-w] [-p] [-help] <sources>...
 Options:
   -w  overwrite source with formatted output. If flag is not present print to stdout
   -p  indent on parens arguments
@@ -16,7 +16,7 @@ Arguments:
 To run the example:
 
 ```bash
-./modelica-fmt examples/gmt-building.mo > examples/gmt-building-out.mo
+./modelicafmt examples/gmt-building.mo > examples/gmt-building-out.mo
 ```
 
 The resulting .mo file can be diffed to the previous file to compare how the modelica-fmt updates the file.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Modelica Formatter provides the ability to automatically format Modelica cod
 ## Running
 
 ```bash
-modelicafmt [-w] [-p] [-help] <sources>...
+modelica-fmt [-w] [-p] [-help] <sources>...
 Options:
   -w  overwrite source with formatted output. If flag is not present print to stdout
   -p  indent on parens arguments
@@ -16,7 +16,7 @@ Arguments:
 To run the example:
 
 ```bash
-./modelicafmt examples/gmt-building.mo > examples/gmt-building-out.mo
+./modelica-fmt examples/gmt-building.mo > examples/gmt-building-out.mo
 ```
 
 The resulting .mo file can be diffed to the previous file to compare how the modelica-fmt updates the file.

--- a/README.md
+++ b/README.md
@@ -21,13 +21,28 @@ To run the example:
 
 The resulting .mo file can be diffed to the previous file to compare how the modelica-fmt updates the file.
 
+## Usage with pre-commit framework
+After adding modelicafmt to your system path, add the following lines to your .pre-commit-config.yaml file under the `repos:` section
+```yaml
+-
+  repo: local
+  hooks:
+  -
+    id: modelica-fmt
+    name: Modelica Formatter
+    entry: modelicafmt
+    args: ["-w"]
+    language: system
+```
+See https://pre-commit.com/ for more information about the framework.
+
 ## Building
 
 ```bash
 brew install go
 
 # in the repository root directory
-go build
+go build -o modelicafmt
 ```
 
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/urbanopt/modelicafmt
+module github.com/urbanopt/modelica-fmt
 
 go 1.13
 

--- a/modelicafmt.go
+++ b/modelicafmt.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
-	"github.com/urbanopt/modelicafmt/thirdparty/parser"
+	"github.com/urbanopt/modelica-fmt/thirdparty/parser"
 )
 
 var alwaysIndentParens = false


### PR DESCRIPTION
### Changes
- changed the module name to modelica-fmt rather than modelicafmt. As a result the when building the executable you should use `go build -o modelicafmt`

### Fixes
- fixed the travis configuration for running goreleaser. Now, whenever we push a tag, travis will use goreleaser to build executables and upload them as assets on the release.