### PR TITLE
refactor!: always indent modifications and arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@ The Modelica Formatter provides the ability to automatically format Modelica cod
 ## Running
 
 ```bash
-modelicafmt [-w] [-p] [-help] <sources>...
+modelicafmt [-w] [-help] <sources>...
 Options:
   -w  overwrite source with formatted output. If flag is not present print to stdout
-  -p  indent on parens arguments
 Arguments:
   sources  one or more files or directories to format
 ```

--- a/main.go
+++ b/main.go
@@ -16,8 +16,7 @@ import (
 )
 
 var (
-	parens = flag.Bool("p", false, "always break and indent contents in parentheses")
-	write  = flag.Bool("w", false, "overwrite the file(s)")
+	write = flag.Bool("w", false, "overwrite the file(s)")
 )
 
 func usage() {
@@ -69,10 +68,6 @@ func main() {
 	if flag.NArg() == 0 {
 		fmt.Fprintln(os.Stderr, "error: must provide at least one file or directory")
 		os.Exit(2)
-	}
-
-	if *parens {
-		alwaysIndentParens = true
 	}
 
 	for i := 0; i < flag.NArg(); i++ {

--- a/modelicafmt.go
+++ b/modelicafmt.go
@@ -13,8 +13,6 @@ import (
 	"github.com/urbanopt/modelica-fmt/thirdparty/parser"
 )
 
-var alwaysIndentParens = false
-
 const (
 	// lexer token types for comments
 	commentTokenType     = 93
@@ -42,9 +40,9 @@ func (l *modelicaListener) insertIndentBefore(rule antlr.ParserRuleContext) bool
 	case
 		parser.IArgumentContext,
 		parser.INamed_argumentContext:
-		return alwaysIndentParens && 0 == l.inAnnotation
+		return 0 == l.inAnnotation
 	case parser.IFunction_argumentContext:
-		return alwaysIndentParens && 0 == l.inNamedArgument && 0 == l.inVector && 0 == l.inAnnotation
+		return 0 == l.inNamedArgument && 0 == l.inVector && 0 == l.inAnnotation
 	default:
 		return false
 	}


### PR DESCRIPTION
### Changes
- Make indenting on modifications and arguments the default behavior and remove the -p flag