### PR TITLE
fix(modelicafmt): add comments trailing at end of file

### DIFF
--- a/examples/gmt-building-out.mo
+++ b/examples/gmt-building-out.mo
@@ -187,3 +187,4 @@ First implementation.
 </ul>
 </html>"));
 end building;
+/* trailing comment */

--- a/examples/gmt-building.mo
+++ b/examples/gmt-building.mo
@@ -222,3 +222,4 @@ First implementation.
 </ul>
 </html>"));
 end building;
+/* trailing comment */

--- a/modelicafmt.go
+++ b/modelicafmt.go
@@ -423,5 +423,13 @@ func processFile(filename string, out io.Writer) error {
 	defer listener.close()
 
 	antlr.ParseTreeWalkerDefault.Walk(listener, sd)
+	// add any remaining comments and handle newline at end of file
+	for _, comment := range listener.commentTokens {
+		listener.writeComment(comment)
+	}
+	if !listener.onNewLine {
+		listener.writeNewline()
+	}
+
 	return nil
 }


### PR DESCRIPTION
### Changes
- previously, we were only adding comments that appeared between non-comment tokens, meaning that any comments at the end of the file were being dropped. This PR fixes that
