### PR TITLE
feat: add flag to display version info

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,13 @@ import (
 )
 
 var (
-	write = flag.Bool("w", false, "overwrite the file(s)")
+	write       = flag.Bool("w", false, "overwrite the file(s)")
+	versionFlag = flag.Bool("v", false, "display tool version")
+	// build information added by goreleaser
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+	builtBy = "unknown"
 )
 
 func usage() {
@@ -65,6 +71,10 @@ func walkDir(path string) {
 func main() {
 	flag.Usage = usage
 	flag.Parse()
+	if *versionFlag {
+		fmt.Printf("modelicafmt v%s (SHA %s)\nBuilt %s by %s\n", version, commit, date, builtBy)
+		return
+	}
 	if flag.NArg() == 0 {
 		fmt.Fprintln(os.Stderr, "error: must provide at least one file or directory")
 		os.Exit(2)


### PR DESCRIPTION
## Context
addresses #16 

## Changes
- change main.go to allow displaying version/build information. goreleaser will automatically update these variables using ldflags when building the release assets in the future. If a user wants to include this when building themselves (not recommended), they can run the following (with the shell variables set or replaced)
```bash
go build -o modelicafmt -ldflags="-X main.version=$version -X main.commit=$commit -X main.date=$date -X main.builtBy=$builtBy
```

## Example output
```bash
╰─$ ./dist/modelica-fmt_darwin_amd64/modelicafmt -v       
modelicafmt v0.1 (SHA 09181bfc4d7482d4dae703af7872e9864fc545d3)
Built 2020-10-06T15:56:56Z by goreleaser
```