### PR TITLE
Add `--rm` to `docker run` so antlr container leftovers are removed

### DIFF
--- a/generate_parser.sh
+++ b/generate_parser.sh
@@ -2,6 +2,6 @@
 
 docker build -t antlr4:latest -f thirdparty/Dockerfile-Antlr .
 
-docker run -v "$(pwd)/thirdparty":/var/antlrResult \
+docker run --rm -v "$(pwd)/thirdparty":/var/antlrResult \
         antlr4:latest \
         -Dlanguage=Go -o /var/antlrResult/parser /var/antlrResult/Modelica.g4


### PR DESCRIPTION
Just a small change, I noticed that this bash script runs docker without `--rm`, so after every run docker clutters the disk with container leftovers that need to be manually clean up.