### PR TITLE
[WIP] Add blank lines after semicolons

### DIFF
--- a/examples/example-arrays-out.mo
+++ b/examples/example-arrays-out.mo
@@ -35,4 +35,3 @@ class MyClass
     annotation (Dialog(group="Fan"));
 
 end MyClass;
-

--- a/examples/example-arrays-out.mo
+++ b/examples/example-arrays-out.mo
@@ -1,0 +1,38 @@
+within Somewhere;
+class MyClass
+  "Class to demo formatting arrays and matrices"
+  extends Modelica.Icons.BasesPackage;
+
+  parameter Real var1=3.14;
+
+  parameter Real x[3];
+
+  parameter Real y[3]={1.0,0.0,-1.0};
+
+  parameter Real z[5]={1.0,0.0,-1.0,2.0,0.0};
+
+  parameter Real A[2,3]={{1.0,2.0,3.0},{5.0,6.0,7.0}};
+
+  parameter Real B[:,3]={{1.0,2.0,3.0},{5.0,6.0,7.0},{1.0,2.0,3.0},{5.0,6.0,7.0},{1.0,2.0,3.0},{5.0,6.0,7.0},{1.0,2.0,3.0},{5.0,6.0,7.0}};
+
+  parameter Real C[2,3]=[
+    1.0,2.0,3.0;
+    5.0,6.0,7.0];
+
+  parameter Integer D[4,3]=[
+    0,1,1;
+    2,3,5;
+    8,13,21;
+    34,55,89];
+
+  parameter Real fraPFan_nominal(
+    unit="W/(kg/s)")=275/0.15
+    "Fan power divided by water mass flow rate at design condition"
+    annotation (Dialog(group="Fan"));
+
+  parameter Modelica.SIunits.Power PFan_nominal=fraPFan_nominal*m_flow_nominal
+    "Fan power"
+    annotation (Dialog(group="Fan"));
+
+end MyClass;
+

--- a/examples/example-arrays.mo
+++ b/examples/example-arrays.mo
@@ -1,0 +1,33 @@
+within Somewhere;
+class MyClass
+  "Class to demo formatting arrays and matrices"
+  extends Modelica.Icons.BasesPackage;
+
+  parameter Real var1 = 3.14;
+
+parameter Real x[3];
+parameter Real y[3] = {1.0, 0.0, -1.0};
+parameter Real z[5] = {1.0, 0.0, -1.0, 2.0, 0.0};
+
+parameter Real A[2,3] = {{1.0, 2.0, 3.0}, {5.0, 6.0, 7.0}};
+
+parameter Real B[:,3] = {{1.0, 2.0, 3.0}, {5.0, 6.0, 7.0}, {1.0, 2.0, 3.0}, {5.0, 6.0, 7.0}, {1.0, 2.0, 3.0}, {5.0, 6.0, 7.0}, {1.0, 2.0, 3.0}, {5.0, 6.0, 7.0}};
+
+
+  parameter Real C[2,3] = [1.0, 2.0, 3.0; 5.0, 6.0, 7.0];
+
+  parameter Integer D[4,3] = [
+    0, 1, 1;
+    2, 3, 5;
+    8, 13, 21;
+    34, 55, 89
+  ];
+
+    parameter Real fraPFan_nominal(unit="W/(kg/s)") = 275/0.15
+        "Fan power divided by water mass flow rate at design condition"
+            annotation (Dialog(group="Fan"));
+    parameter Modelica.SIunits.Power PFan_nominal = fraPFan_nominal*m_flow_nominal
+        "Fan power"
+            annotation (Dialog(group="Fan"));
+
+end MyClass;

--- a/examples/example-no-within-out.mo
+++ b/examples/example-no-within-out.mo
@@ -30,4 +30,3 @@ class MyClass
   end destructor;
 
 end MyClass;
-

--- a/examples/example-no-within-out.mo
+++ b/examples/example-no-within-out.mo
@@ -1,4 +1,3 @@
-within Somewhere;
 class MyClass
   "Class to demo function definitions"
   extends Modelica.Icons.BasesPackage;

--- a/examples/example-no-within.mo
+++ b/examples/example-no-within.mo
@@ -1,4 +1,3 @@
-within Somewhere;
 class MyClass
   "Class to demo function definitions"
   extends Modelica.Icons.BasesPackage;
@@ -7,28 +6,15 @@ class MyClass
     "Construct to connect to a schedule in EnergyPlus"
     extends Modelica.Icons.Function;
 
-    input Integer input1
-      "input 1 comment";
-
+    input Integer input1 "input 1 comment";
     output MyClass adapter;
-
-  external "C" adapter=ExternalFunctionCall(
-    param1,
-    param2,
-    param3);
-
+    external "C" adapter = ExternalFunctionCall(param1, param2, param3);
   end constructor;
 
-  function destructor
-    "Some comment"
+  function destructor "Some comment"
     extends Modelica.Icons.Function;
 
     input Integer input2;
-
-  external "C" EnergyPlusInputVariableFree(
-    input2);
-
+    external "C" EnergyPlusInputVariableFree(input2);
   end destructor;
-
 end MyClass;
-

--- a/examples/functions-out.mo
+++ b/examples/functions-out.mo
@@ -31,4 +31,3 @@ class MyClass
   end destructor;
 
 end MyClass;
-

--- a/examples/gmt-building-80-out.mo
+++ b/examples/gmt-building-80-out.mo
@@ -7,16 +7,22 @@ model building
     have_fan=false,
     have_eleHea=false,
     have_eleCoo=false);
+
   package MediumW=Buildings.Media.Water
     "Source side medium";
+
   package MediumA=Buildings.Media.Air
     "Load side medium";
+
   parameter Integer nZon=6
     "Number of thermal zones";
+
   parameter Integer facSca=3
     "Scaling factor to be applied to on each extensive quantity";
+
   parameter Modelica.SIunits.TemperatureDifference delTBuiCoo=5
     "Nominal building supply and return chilled water temperature difference";
+
   Buildings.Controls.OBC.CDL.Continuous.Sources.Constant minTSet[nZon](
     k=fill(
       293.15,
@@ -26,6 +32,7 @@ model building
       each displayUnit="degC"))
     "Minimum temperature set point"
     annotation (Placement(transformation(extent={{-290,230},{-270,250}})));
+
   Buildings.Controls.OBC.CDL.Continuous.Sources.Constant maxTSet[nZon](
     k=fill(
       297.15,
@@ -35,21 +42,29 @@ model building
       each displayUnit="degC"))
     "Maximum temperature set point"
     annotation (Placement(transformation(extent={{-290,190},{-270,210}})));
+
   Meeting meeting
     annotation (Placement(transformation(extent={{-160,-20},{-140,0}})));
+
   Floor floor
     annotation (Placement(transformation(extent={{-120,-20},{-100,0}})));
+
   Storage storage
     annotation (Placement(transformation(extent={{-80,-20},{-60,0}})));
+
   Office office
     annotation (Placement(transformation(extent={{-40,-20},{-20,0}})));
+
   Restroom restroom
     annotation (Placement(transformation(extent={{0,-20},{20,0}})));
+
   ICT ict
     annotation (Placement(transformation(extent={{40,-20},{60,0}})));
+
   Buildings.Controls.OBC.CDL.Continuous.MultiSum mulSum(
     nin=2) if have_pum
     annotation (Placement(transformation(extent={{260,70},{280,90}})));
+
   Buildings.Applications.DHC.Loads.Examples.BaseClasses.FanCoil4PipeHeatPorts terUni[nZon](
     redeclare each package Medium1=MediumW,
     redeclare each package Medium2=MediumA,
@@ -66,6 +81,7 @@ model building
     each mLoaCoo_flow_nominal=5)
     "Terminal unit"
     annotation (Placement(transformation(extent={{-200,-60},{-180,-40}})));
+
   Buildings.Applications.DHC.Loads.BaseClasses.FlowDistribution disFloHea(
     redeclare package Medium=MediumW,
     m_flow_nominal=sum(
@@ -77,6 +93,7 @@ model building
     nPorts_b1=nZon)
     "Heating water distribution system"
     annotation (Placement(transformation(extent={{-140,-100},{-120,-80}})));
+
   Buildings.Applications.DHC.Loads.BaseClasses.FlowDistribution disFloCoo(
     redeclare package Medium=MediumW,
     m_flow_nominal=sum(
@@ -89,111 +106,147 @@ model building
     nPorts_b1=nZon)
     "Chilled water distribution system"
     annotation (Placement(transformation(extent={{-140,-160},{-120,-140}})));
+
 equation
   connect(disFloHea.port_b,secHeaRet[1])
     annotation (Line(points={{140,-70},{240,-70},{240,32},{300,32}},color={0,127,
       255}));
+
   connect(disFloHea.port_a,secHeaSup[1])
     annotation (Line(points={{120,-70},{-242,-70},{-242,32},{-300,32}},color={0,
       127,255}));
+
   connect(disFloCoo.port_b,secCooRet[1])
     annotation (Line(points={{140,-110},{252,-110},{252,-30},{300,-30}},color={0,
       127,255}));
+
   connect(disFloCoo.port_a,secCooSup[1])
     annotation (Line(points={{120,-110},{-280,-110},{-280,-30},{-300,-30}},color=
       {0,127,255}));
+
   connect(disFloHea.ports_a1,terUni.port_bHeaWat)
     annotation (Line(points={{-120,-80.6667},{-104,-80.6667},{-104,-58.3333},{-180,
       -58.3333}},color={0,127,255}));
+
   connect(disFloHea.ports_b1,terUni.port_aHeaWat)
     annotation (Line(points={{-140,-80.6667},{-216,-80.6667},{-216,-58.3333},{-200,
       -58.3333}},color={0,127,255}));
+
   connect(disFloCoo.ports_a1,terUni.port_bChiWat)
     annotation (Line(points={{-120,-144},{-94,-144},{-94,-56},{-180,-56},{-180,-56.6667}},
       color={0,127,255}));
+
   connect(disFloCoo.ports_b1,terUni.port_aChiWat)
     annotation (Line(points={{-140,-144},{-226,-144},{-226,-56.6667},{-200,-56.6667}},
       color={0,127,255}));
+
   connect(weaBus,meeting.weaBus)
     annotation (Line(points={{1,300},{0,300},{0,20},{-66,20},{-66,-10.2},{-96,-10.2}},
       color={255,204,51},thickness=0.5),Text(string="%first",index=-1,extent={{6,
       3},{6,3}},horizontalAlignment=TextAlignment.Left));
+
   connect(terUni[0+1].heaPorCon,meeting.port_a)
     annotation (Line(points={{-193.333,-50},{-192,-50},{-192,0},{-90,0}},color={191,
       0,0}));
+
   connect(terUni[0+1].heaPorRad,meeting.port_a)
     annotation (Line(points={{-186.667,-50},{-90,-50},{-90,0}},color={191,0,0}));
+
   connect(weaBus,floor.weaBus)
     annotation (Line(points={{1,300},{0,300},{0,20},{-66,20},{-66,-10.2},{-96,-10.2}},
       color={255,204,51},thickness=0.5),Text(string="%first",index=-1,extent={{6,
       3},{6,3}},horizontalAlignment=TextAlignment.Left));
+
   connect(terUni[1+1].heaPorCon,floor.port_a)
     annotation (Line(points={{-193.333,-50},{-192,-50},{-192,0},{-90,0}},color={191,
       0,0}));
+
   connect(terUni[1+1].heaPorRad,floor.port_a)
     annotation (Line(points={{-186.667,-50},{-90,-50},{-90,0}},color={191,0,0}));
+
   connect(weaBus,storage.weaBus)
     annotation (Line(points={{1,300},{0,300},{0,20},{-66,20},{-66,-10.2},{-96,-10.2}},
       color={255,204,51},thickness=0.5),Text(string="%first",index=-1,extent={{6,
       3},{6,3}},horizontalAlignment=TextAlignment.Left));
+
   connect(terUni[2+1].heaPorCon,storage.port_a)
     annotation (Line(points={{-193.333,-50},{-192,-50},{-192,0},{-90,0}},color={191,
       0,0}));
+
   connect(terUni[2+1].heaPorRad,storage.port_a)
     annotation (Line(points={{-186.667,-50},{-90,-50},{-90,0}},color={191,0,0}));
+
   connect(weaBus,office.weaBus)
     annotation (Line(points={{1,300},{0,300},{0,20},{-66,20},{-66,-10.2},{-96,-10.2}},
       color={255,204,51},thickness=0.5),Text(string="%first",index=-1,extent={{6,
       3},{6,3}},horizontalAlignment=TextAlignment.Left));
+
   connect(terUni[3+1].heaPorCon,office.port_a)
     annotation (Line(points={{-193.333,-50},{-192,-50},{-192,0},{-90,0}},color={191,
       0,0}));
+
   connect(terUni[3+1].heaPorRad,office.port_a)
     annotation (Line(points={{-186.667,-50},{-90,-50},{-90,0}},color={191,0,0}));
+
   connect(weaBus,restroom.weaBus)
     annotation (Line(points={{1,300},{0,300},{0,20},{-66,20},{-66,-10.2},{-96,-10.2}},
       color={255,204,51},thickness=0.5),Text(string="%first",index=-1,extent={{6,
       3},{6,3}},horizontalAlignment=TextAlignment.Left));
+
   connect(terUni[4+1].heaPorCon,restroom.port_a)
     annotation (Line(points={{-193.333,-50},{-192,-50},{-192,0},{-90,0}},color={191,
       0,0}));
+
   connect(terUni[4+1].heaPorRad,restroom.port_a)
     annotation (Line(points={{-186.667,-50},{-90,-50},{-90,0}},color={191,0,0}));
+
   connect(weaBus,ict.weaBus)
     annotation (Line(points={{1,300},{0,300},{0,20},{-66,20},{-66,-10.2},{-96,-10.2}},
       color={255,204,51},thickness=0.5),Text(string="%first",index=-1,extent={{6,
       3},{6,3}},horizontalAlignment=TextAlignment.Left));
+
   connect(terUni[5+1].heaPorCon,ict.port_a)
     annotation (Line(points={{-193.333,-50},{-192,-50},{-192,0},{-90,0}},color={191,
       0,0}));
+
   connect(terUni[5+1].heaPorRad,ict.port_a)
     annotation (Line(points={{-186.667,-50},{-90,-50},{-90,0}},color={191,0,0}));
+
   connect(terUni.mReqHeaWat_flow,disFloHea.mReq_flow)
     annotation (Line(points={{-179.167,-53.3333},{-179.167,-54},{-170,-54},{-170,
       -94},{-141,-94}},color={0,0,127}));
+
   connect(terUni.mReqChiWat_flow,disFloCoo.mReq_flow)
     annotation (Line(points={{-179.167,-55},{-179.167,-56},{-172,-56},{-172,-154},
       {-141,-154}},color={0,0,127}));
+
   connect(mulSum.y,PPum)
     annotation (Line(points={{282,80},{320,80}},color={0,0,127}));
+
   connect(disFloHea.PPum,mulSum.u[1])
     annotation (Line(points={{-119,-98},{240,-98},{240,81},{258,81}},color={0,0,
       127}));
+
   connect(disFloCoo.PPum,mulSum.u[2])
     annotation (Line(points={{-119,-158},{240,-158},{240,79},{258,79}},color={0,
       0,127}));
+
   connect(disFloHea.QActTot_flow,QHea_flow)
     annotation (Line(points={{-119,-96},{223.5,-96},{223.5,280},{320,280}},color=
       {0,0,127}));
+
   connect(disFloCoo.QActTot_flow,QCoo_flow)
     annotation (Line(points={{-119,-156},{230,-156},{230,240},{320,240}},color={0,
       0,127}));
+
   connect(maxTSet.y,terUni.TSetCoo)
     annotation (Line(points={{-268,200},{-240,200},{-240,-46.6667},{-200.833,-46.6667}},
       color={0,0,127}));
+
   connect(minTSet.y,terUni.TSetHea)
     annotation (Line(points={{-268,240},{-220,240},{-220,-45},{-200.833,-45}},
       color={0,0,127}));
+
   annotation (
     Documentation(
       info="
@@ -249,5 +302,7 @@ First implementation.
           fillColor={0,0,0},
           fillPattern=FillPattern.Solid,
           pattern=LinePattern.None)}));
+
 end building;
+
 /* trailing comment */

--- a/examples/gmt-building-out.mo
+++ b/examples/gmt-building-out.mo
@@ -7,16 +7,22 @@ model building
     have_fan=false,
     have_eleHea=false,
     have_eleCoo=false);
+
   package MediumW=Buildings.Media.Water
     "Source side medium";
+
   package MediumA=Buildings.Media.Air
     "Load side medium";
+
   parameter Integer nZon=6
     "Number of thermal zones";
+
   parameter Integer facSca=3
     "Scaling factor to be applied to on each extensive quantity";
+
   parameter Modelica.SIunits.TemperatureDifference delTBuiCoo=5
     "Nominal building supply and return chilled water temperature difference";
+
   Buildings.Controls.OBC.CDL.Continuous.Sources.Constant minTSet[nZon](
     k=fill(
       293.15,
@@ -26,6 +32,7 @@ model building
       each displayUnit="degC"))
     "Minimum temperature set point"
     annotation (Placement(transformation(extent={{-290,230},{-270,250}})));
+
   Buildings.Controls.OBC.CDL.Continuous.Sources.Constant maxTSet[nZon](
     k=fill(
       297.15,
@@ -35,21 +42,29 @@ model building
       each displayUnit="degC"))
     "Maximum temperature set point"
     annotation (Placement(transformation(extent={{-290,190},{-270,210}})));
+
   Meeting meeting
     annotation (Placement(transformation(extent={{-160,-20},{-140,0}})));
+
   Floor floor
     annotation (Placement(transformation(extent={{-120,-20},{-100,0}})));
+
   Storage storage
     annotation (Placement(transformation(extent={{-80,-20},{-60,0}})));
+
   Office office
     annotation (Placement(transformation(extent={{-40,-20},{-20,0}})));
+
   Restroom restroom
     annotation (Placement(transformation(extent={{0,-20},{20,0}})));
+
   ICT ict
     annotation (Placement(transformation(extent={{40,-20},{60,0}})));
+
   Buildings.Controls.OBC.CDL.Continuous.MultiSum mulSum(
     nin=2) if have_pum
     annotation (Placement(transformation(extent={{260,70},{280,90}})));
+
   Buildings.Applications.DHC.Loads.Examples.BaseClasses.FanCoil4PipeHeatPorts terUni[nZon](
     redeclare each package Medium1=MediumW,
     redeclare each package Medium2=MediumA,
@@ -66,6 +81,7 @@ model building
     each mLoaCoo_flow_nominal=5)
     "Terminal unit"
     annotation (Placement(transformation(extent={{-200,-60},{-180,-40}})));
+
   Buildings.Applications.DHC.Loads.BaseClasses.FlowDistribution disFloHea(
     redeclare package Medium=MediumW,
     m_flow_nominal=sum(
@@ -77,6 +93,7 @@ model building
     nPorts_b1=nZon)
     "Heating water distribution system"
     annotation (Placement(transformation(extent={{-140,-100},{-120,-80}})));
+
   Buildings.Applications.DHC.Loads.BaseClasses.FlowDistribution disFloCoo(
     redeclare package Medium=MediumW,
     m_flow_nominal=sum(
@@ -89,77 +106,113 @@ model building
     nPorts_b1=nZon)
     "Chilled water distribution system"
     annotation (Placement(transformation(extent={{-140,-160},{-120,-140}})));
+
 equation
   connect(disFloHea.port_b,secHeaRet[1])
     annotation (Line(points={{140,-70},{240,-70},{240,32},{300,32}},color={0,127,255}));
+
   connect(disFloHea.port_a,secHeaSup[1])
     annotation (Line(points={{120,-70},{-242,-70},{-242,32},{-300,32}},color={0,127,255}));
+
   connect(disFloCoo.port_b,secCooRet[1])
     annotation (Line(points={{140,-110},{252,-110},{252,-30},{300,-30}},color={0,127,255}));
+
   connect(disFloCoo.port_a,secCooSup[1])
     annotation (Line(points={{120,-110},{-280,-110},{-280,-30},{-300,-30}},color={0,127,255}));
+
   connect(disFloHea.ports_a1,terUni.port_bHeaWat)
     annotation (Line(points={{-120,-80.6667},{-104,-80.6667},{-104,-58.3333},{-180,-58.3333}},color={0,127,255}));
+
   connect(disFloHea.ports_b1,terUni.port_aHeaWat)
     annotation (Line(points={{-140,-80.6667},{-216,-80.6667},{-216,-58.3333},{-200,-58.3333}},color={0,127,255}));
+
   connect(disFloCoo.ports_a1,terUni.port_bChiWat)
     annotation (Line(points={{-120,-144},{-94,-144},{-94,-56},{-180,-56},{-180,-56.6667}},color={0,127,255}));
+
   connect(disFloCoo.ports_b1,terUni.port_aChiWat)
     annotation (Line(points={{-140,-144},{-226,-144},{-226,-56.6667},{-200,-56.6667}},color={0,127,255}));
+
   connect(weaBus,meeting.weaBus)
     annotation (Line(points={{1,300},{0,300},{0,20},{-66,20},{-66,-10.2},{-96,-10.2}},color={255,204,51},thickness=0.5),Text(string="%first",index=-1,extent={{6,3},{6,3}},horizontalAlignment=TextAlignment.Left));
+
   connect(terUni[0+1].heaPorCon,meeting.port_a)
     annotation (Line(points={{-193.333,-50},{-192,-50},{-192,0},{-90,0}},color={191,0,0}));
+
   connect(terUni[0+1].heaPorRad,meeting.port_a)
     annotation (Line(points={{-186.667,-50},{-90,-50},{-90,0}},color={191,0,0}));
+
   connect(weaBus,floor.weaBus)
     annotation (Line(points={{1,300},{0,300},{0,20},{-66,20},{-66,-10.2},{-96,-10.2}},color={255,204,51},thickness=0.5),Text(string="%first",index=-1,extent={{6,3},{6,3}},horizontalAlignment=TextAlignment.Left));
+
   connect(terUni[1+1].heaPorCon,floor.port_a)
     annotation (Line(points={{-193.333,-50},{-192,-50},{-192,0},{-90,0}},color={191,0,0}));
+
   connect(terUni[1+1].heaPorRad,floor.port_a)
     annotation (Line(points={{-186.667,-50},{-90,-50},{-90,0}},color={191,0,0}));
+
   connect(weaBus,storage.weaBus)
     annotation (Line(points={{1,300},{0,300},{0,20},{-66,20},{-66,-10.2},{-96,-10.2}},color={255,204,51},thickness=0.5),Text(string="%first",index=-1,extent={{6,3},{6,3}},horizontalAlignment=TextAlignment.Left));
+
   connect(terUni[2+1].heaPorCon,storage.port_a)
     annotation (Line(points={{-193.333,-50},{-192,-50},{-192,0},{-90,0}},color={191,0,0}));
+
   connect(terUni[2+1].heaPorRad,storage.port_a)
     annotation (Line(points={{-186.667,-50},{-90,-50},{-90,0}},color={191,0,0}));
+
   connect(weaBus,office.weaBus)
     annotation (Line(points={{1,300},{0,300},{0,20},{-66,20},{-66,-10.2},{-96,-10.2}},color={255,204,51},thickness=0.5),Text(string="%first",index=-1,extent={{6,3},{6,3}},horizontalAlignment=TextAlignment.Left));
+
   connect(terUni[3+1].heaPorCon,office.port_a)
     annotation (Line(points={{-193.333,-50},{-192,-50},{-192,0},{-90,0}},color={191,0,0}));
+
   connect(terUni[3+1].heaPorRad,office.port_a)
     annotation (Line(points={{-186.667,-50},{-90,-50},{-90,0}},color={191,0,0}));
+
   connect(weaBus,restroom.weaBus)
     annotation (Line(points={{1,300},{0,300},{0,20},{-66,20},{-66,-10.2},{-96,-10.2}},color={255,204,51},thickness=0.5),Text(string="%first",index=-1,extent={{6,3},{6,3}},horizontalAlignment=TextAlignment.Left));
+
   connect(terUni[4+1].heaPorCon,restroom.port_a)
     annotation (Line(points={{-193.333,-50},{-192,-50},{-192,0},{-90,0}},color={191,0,0}));
+
   connect(terUni[4+1].heaPorRad,restroom.port_a)
     annotation (Line(points={{-186.667,-50},{-90,-50},{-90,0}},color={191,0,0}));
+
   connect(weaBus,ict.weaBus)
     annotation (Line(points={{1,300},{0,300},{0,20},{-66,20},{-66,-10.2},{-96,-10.2}},color={255,204,51},thickness=0.5),Text(string="%first",index=-1,extent={{6,3},{6,3}},horizontalAlignment=TextAlignment.Left));
+
   connect(terUni[5+1].heaPorCon,ict.port_a)
     annotation (Line(points={{-193.333,-50},{-192,-50},{-192,0},{-90,0}},color={191,0,0}));
+
   connect(terUni[5+1].heaPorRad,ict.port_a)
     annotation (Line(points={{-186.667,-50},{-90,-50},{-90,0}},color={191,0,0}));
+
   connect(terUni.mReqHeaWat_flow,disFloHea.mReq_flow)
     annotation (Line(points={{-179.167,-53.3333},{-179.167,-54},{-170,-54},{-170,-94},{-141,-94}},color={0,0,127}));
+
   connect(terUni.mReqChiWat_flow,disFloCoo.mReq_flow)
     annotation (Line(points={{-179.167,-55},{-179.167,-56},{-172,-56},{-172,-154},{-141,-154}},color={0,0,127}));
+
   connect(mulSum.y,PPum)
     annotation (Line(points={{282,80},{320,80}},color={0,0,127}));
+
   connect(disFloHea.PPum,mulSum.u[1])
     annotation (Line(points={{-119,-98},{240,-98},{240,81},{258,81}},color={0,0,127}));
+
   connect(disFloCoo.PPum,mulSum.u[2])
     annotation (Line(points={{-119,-158},{240,-158},{240,79},{258,79}},color={0,0,127}));
+
   connect(disFloHea.QActTot_flow,QHea_flow)
     annotation (Line(points={{-119,-96},{223.5,-96},{223.5,280},{320,280}},color={0,0,127}));
+
   connect(disFloCoo.QActTot_flow,QCoo_flow)
     annotation (Line(points={{-119,-156},{230,-156},{230,240},{320,240}},color={0,0,127}));
+
   connect(maxTSet.y,terUni.TSetCoo)
     annotation (Line(points={{-268,200},{-240,200},{-240,-46.6667},{-200.833,-46.6667}},color={0,0,127}));
+
   connect(minTSet.y,terUni.TSetHea)
     annotation (Line(points={{-268,240},{-220,240},{-220,-45},{-200.833,-45}},color={0,0,127}));
+
   annotation (
     Documentation(
       info="
@@ -215,5 +268,7 @@ First implementation.
           fillColor={0,0,0},
           fillPattern=FillPattern.Solid,
           pattern=LinePattern.None)}));
+
 end building;
+
 /* trailing comment */

--- a/examples/gmt-coolingtower-out.mo
+++ b/examples/gmt-coolingtower-out.mo
@@ -395,4 +395,3 @@ First implementation.
 </html>"));
 
 end Merkel;
-

--- a/examples/gmt-coolingtower-out.mo
+++ b/examples/gmt-coolingtower-out.mo
@@ -3,41 +3,52 @@ within Buildings.Fluid.HeatExchangers.CoolingTowers;
 model Merkel
   "Cooling tower model based on Merkel's theory"
   extends Buildings.Fluid.HeatExchangers.CoolingTowers.BaseClasses.CoolingTower;
+
   import cha=Buildings.Fluid.HeatExchangers.CoolingTowers.BaseClasses.Characteristics;
+
   final parameter Modelica.SIunits.MassFlowRate mAir_flow_nominal=m_flow_nominal/ratWatAir_nominal
     "Nominal mass flow rate of air"
     annotation (Dialog(group="Fan"));
+
   parameter Real ratWatAir_nominal(
     min=0,
     unit="1")=1.2
     "Water-to-air mass flow rate ratio at design condition"
     annotation (Dialog(group="Nominal condition"));
+
   parameter Modelica.SIunits.Temperature TAirInWB_nominal
     "Nominal outdoor (air inlet) wetbulb temperature"
     annotation (Dialog(group="Heat transfer"));
+
   parameter Modelica.SIunits.Temperature TWatIn_nominal
     "Nominal water inlet temperature"
     annotation (Dialog(group="Heat transfer"));
+
   parameter Modelica.SIunits.Temperature TWatOut_nominal
     "Nominal water outlet temperature"
     annotation (Dialog(group="Heat transfer"));
+
   parameter Real fraFreCon(
     min=0,
     max=1,
     final unit="1")=0.125
     "Fraction of tower capacity in free convection regime"
     annotation (Dialog(group="Heat transfer"));
+
   replaceable parameter Buildings.Fluid.HeatExchangers.CoolingTowers.Data.UAMerkel UACor
     constrainedby Buildings.Fluid.HeatExchangers.CoolingTowers.Data.UAMerkel
     "Coefficients for UA correction"
     annotation (Dialog(group="Heat transfer"),choicesAllMatching=true,Placement(transformation(extent={{18,70},{38,90}})));
+
   parameter Real fraPFan_nominal(
     unit="W/(kg/s)")=275/0.15
     "Fan power divided by water mass flow rate at design condition"
     annotation (Dialog(group="Fan"));
+
   parameter Modelica.SIunits.Power PFan_nominal=fraPFan_nominal*m_flow_nominal
     "Fan power"
     annotation (Dialog(group="Fan"));
+
   parameter Real yMin(
     min=0.01,
     max=1,
@@ -45,32 +56,40 @@ model Merkel
     "Minimum control signal until fan is switched off (used for smoothing
     between forced and free convection regime)"
     annotation (Dialog(group="Fan"));
+
   replaceable parameter cha.fan fanRelPow(
     r_V={0,0.1,0.3,0.6,1},
     r_P={0,0.1^3,0.3^3,0.6^3,1})
     constrainedby cha.fan
     "Fan relative power consumption as a function of control signal, fanRelPow=P(y)/P(y=1)"
     annotation (choicesAllMatching=true,Placement(transformation(extent={{58,70},{78,90}})),Dialog(group="Fan"));
+
   final parameter Modelica.SIunits.HeatFlowRate Q_flow_nominal(
     max=0)=per.Q_flow_nominal
     "Nominal heat transfer, (negative)";
+
   final parameter Modelica.SIunits.ThermalConductance UA_nominal=per.UA_nominal
     "Thermal conductance at nominal flow, used to compute heat capacity";
+
   final parameter Real eps_nominal=per.eps_nominal
     "Nominal heat transfer effectiveness";
+
   final parameter Real NTU_nominal(
     min=0)=per.NTU_nominal
     "Nominal number of transfer units";
+
   Modelica.Blocks.Interfaces.RealInput TAir(
     final min=0,
     final unit="K",
     displayUnit="degC")
     "Entering air wet bulb temperature"
     annotation (Placement(transformation(extent={{-140,20},{-100,60}})));
+
   Modelica.Blocks.Interfaces.RealInput y(
     unit="1")
     "Fan control signal"
     annotation (Placement(transformation(extent={{-140,60},{-100,100}})));
+
   Modelica.Blocks.Interfaces.RealOutput PFan(
     final quantity="Power",
     final unit="W")=Buildings.Utilities.Math.Functions.spliceFunction(
@@ -83,6 +102,7 @@ model Merkel
     deltax=yMin/20)
     "Electric power consumed by fan"
     annotation (Placement(transformation(extent={{100,70},{120,90}}),iconTransformation(extent={{100,70},{120,90}})));
+
 protected
   final parameter Real fanRelPowDer[size(
     fanRelPow.r_V,
@@ -94,6 +114,7 @@ protected
       strict=false))
     "Coefficients for fan relative power consumption as a function
     of control signal";
+
   Modelica.Blocks.Sources.RealExpression TWatIn(
     final y=Medium.temperature(
       Medium.setState_phX(
@@ -102,10 +123,12 @@ protected
         X=inStream(port_a.Xi_outflow))))
     "Water inlet temperature"
     annotation (Placement(transformation(extent={{-70,36},{-50,54}})));
+
   Modelica.Blocks.Sources.RealExpression mWat_flow(
     final y=port_a.m_flow)
     "Water mass flow rate"
     annotation (Placement(transformation(extent={{-70,20},{-50,38}})));
+
   Buildings.Fluid.HeatExchangers.CoolingTowers.BaseClasses.Merkel per(
     redeclare final package Medium=Medium,
     final m_flow_nominal=m_flow_nominal,
@@ -118,6 +141,7 @@ protected
     final yMin=yMin)
     "Model for thermal performance"
     annotation (Placement(transformation(extent={{-20,40},{0,60}})));
+
 initial equation
   // Check validity of relative fan power consumption at y=yMin and y=1
   assert(
@@ -130,6 +154,7 @@ initial equation
         per=fanRelPow,
         r_V=yMin,
         d=fanRelPowDer))+"\n   You need to choose different values for the parameter fanRelPow.");
+
   assert(
     abs(
       1-cha.normalizedPower(
@@ -141,17 +166,23 @@ initial equation
         per=fanRelPow,
         r_V=1,
         d=fanRelPowDer))+"\n   You need to choose different values for the parameter fanRelPow."+"\n   To increase the fan power, change fraPFan_nominal or PFan_nominal.");
+
 equation
   connect(per.y,y)
     annotation (Line(points={{-22,58},{-40,58},{-40,80},{-120,80}},color={0,0,127}));
+
   connect(per.TAir,TAir)
     annotation (Line(points={{-22,54},{-80,54},{-80,40},{-120,40}},color={0,0,127}));
+
   connect(per.Q_flow,preHea.Q_flow)
     annotation (Line(points={{1,50},{12,50},{12,12},{-80,12},{-80,-60},{-40,-60}},color={0,0,127}));
+
   connect(per.m_flow,mWat_flow.y)
     annotation (Line(points={{-22,42},{-34,42},{-34,29},{-49,29}},color={0,0,127}));
+
   connect(TWatIn.y,per.TWatIn)
     annotation (Line(points={{-49,45},{-40,45},{-40,46},{-22,46}},color={0,0,127}));
+
   annotation (
     Icon(
       coordinateSystem(
@@ -362,4 +393,6 @@ First implementation.
 </li>
 </ul>
 </html>"));
+
 end Merkel;
+

--- a/modelicafmt_test.go
+++ b/modelicafmt_test.go
@@ -31,9 +31,11 @@ var exampleFileTests = []struct {
 	outFile    string
 	lineLength int
 }{
-	{"gmt-building.mo", "gmt-building-out.mo", -1},
 	{"gmt-coolingtower.mo", "gmt-coolingtower-out.mo", -1},
 	{"functions.mo", "functions-out.mo", -1},
+	{"example-no-within.mo", "example-no-within-out.mo", -1},
+	{"example-arrays.mo", "example-arrays-out.mo", -1},
+	{"gmt-building.mo", "gmt-building-out.mo", -1},
 	{"gmt-building.mo", "gmt-building-80-out.mo", 80},
 }
 


### PR DESCRIPTION
A blank line is added after every line that:

* Doesn't have `within` statement on it
* Isn't inside `[]` (matrix notation)

Issues:

* Two blank lines are added if a file ends with a semicolon. The tests are not passing because of that.

   I am not sure how to solve this problem. I thought about checking for `end` on a given line, but we can have multiple `end` in one file. And this should only care about the last `end`.

  One of my ideas is to check for main class/model name (i.e. the one in the 2nd line) and add another `if` statement that checks if we're in the correct `end` statement. But I noticed that you have trailing comments at the end of test files (e.g. [this one](https://github.com/urbanopt/modelica-fmt/blob/develop/examples/gmt-building.mo)) so this approach would also break here, because a blank line would be missing, but it shouldn't.

  Any better ideas? I am not too familiar with antrl 😄 

I added new test `.mo` files that help to verify:

* formatting of matrices
* situation when we're missing `within` statement from any reason (might be useful for formatting code snippets etc.)