### PR TITLE
Prevent file modification when the formatter hits a parse error

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,9 @@ var (
 	versionFlag   = flag.Bool("v", false, "display tool version")
 	emptyLineFlag = flag.Bool("extra-padding", false, "BETA: adds empty lines for padding")
 	lineLength    = flag.Int("line-length", -1, "how many characters allowed per line; -1 means no max")
+	// hadError is set to true when a file could not be processed, so the
+	// program can exit with a non-zero status without aborting other files
+	hadError bool
 	// build information added by goreleaser
 	version = "dev"
 	commit  = "none"
@@ -41,7 +44,13 @@ func processAndWriteFile(filename string) {
 	var b bytes.Buffer
 	err := processFile(filename, bufio.NewWriter(&b), Config{*lineLength, *emptyLineFlag})
 	if err != nil {
-		panic(err)
+		// The file could not be parsed cleanly (e.g. it contains an
+		// unrecognized token). Leave the original file untouched and report
+		// the error instead of writing malformed output.
+		fmt.Fprintln(os.Stderr, "error: "+err.Error())
+		fmt.Fprintln(os.Stderr, "skipping "+filename+" (file left unchanged)")
+		hadError = true
+		return
 	}
 	if *write {
 		err := ioutil.WriteFile(filename, b.Bytes(), 777)
@@ -94,5 +103,11 @@ func main() {
 		default:
 			processAndWriteFile(path)
 		}
+	}
+
+	// exit non-zero if any file failed to process so the failure is not
+	// silently ignored (e.g. in CI or pre-commit hooks)
+	if hadError {
+		os.Exit(1)
 	}
 }

--- a/modelicafmt.go
+++ b/modelicafmt.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"strings"
@@ -512,6 +513,25 @@ func (c *commentCollector) NextToken() antlr.Token {
 	return token
 }
 
+// parseErrorListener collects syntax errors encountered while lexing and
+// parsing a file. This includes lexer "token recognition error"s as well as
+// parser errors. It replaces ANTLR's default console error listener so that
+// callers can detect whether a file was parsed cleanly.
+type parseErrorListener struct {
+	*antlr.DefaultErrorListener
+	errors []string
+}
+
+func newParseErrorListener() *parseErrorListener {
+	return &parseErrorListener{
+		DefaultErrorListener: antlr.NewDefaultErrorListener(),
+	}
+}
+
+func (l *parseErrorListener) SyntaxError(recognizer antlr.Recognizer, offendingSymbol interface{}, line, column int, msg string, e antlr.RecognitionException) {
+	l.errors = append(l.errors, fmt.Sprintf("line %d:%d %s", line, column, msg))
+}
+
 // processFile formats a file
 func processFile(filename string, out io.Writer, config Config) error {
 	content, err := ioutil.ReadFile(filename)
@@ -523,12 +543,21 @@ func processFile(filename string, out io.Writer, config Config) error {
 	inputStream := antlr.NewInputStream(text)
 	lexer := parser.NewModelicaLexer(inputStream)
 
+	// collect lexer and parser errors so that a file which fails to parse
+	// (e.g. contains an unrecognized token) is not silently formatted with a
+	// truncated/incorrect parse tree
+	errorListener := newParseErrorListener()
+	lexer.RemoveErrorListeners()
+	lexer.AddErrorListener(errorListener)
+
 	// wrap the default lexer to collect comments and set it as the stream's source
 	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
 	tokenSource := newCommentCollector(lexer)
 	stream.SetTokenSource(&tokenSource)
 
 	p := parser.NewModelicaParser(stream)
+	p.RemoveErrorListeners()
+	p.AddErrorListener(errorListener)
 	sd := p.Stored_definition()
 
 	listener := newListener(out, tokenSource.commentTokens, config)
@@ -541,6 +570,12 @@ func processFile(filename string, out io.Writer, config Config) error {
 	}
 	if !listener.onNewLine {
 		listener.writeNewline()
+	}
+
+	// if any errors were encountered while parsing, report them so that the
+	// caller can avoid overwriting the original file with malformed output
+	if len(errorListener.errors) > 0 {
+		return fmt.Errorf("%s: %s", filename, strings.Join(errorListener.errors, "; "))
 	}
 
 	return nil

--- a/modelicafmt_test.go
+++ b/modelicafmt_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -77,7 +78,7 @@ func TestProcessFileReturnsErrorOnInvalidInput(t *testing.T) {
 
 	invalidContent := "model Test\n  Real x = 1 # bad token;\nequation\n  x = 2;\nend Test;\n"
 	sourceFile := path.Join(outputDir, "invalid-input.mo")
-	a.NoError(os.WriteFile(sourceFile, []byte(invalidContent), 0644))
+	a.NoError(ioutil.WriteFile(sourceFile, []byte(invalidContent), 0644))
 	defer os.Remove(sourceFile)
 
 	var out bytes.Buffer

--- a/modelicafmt_test.go
+++ b/modelicafmt_test.go
@@ -67,3 +67,21 @@ func TestFormattingExamples(t *testing.T) {
 		})
 	}
 }
+
+// TestProcessFileReturnsErrorOnInvalidInput ensures that processFile returns an
+// error when the input cannot be parsed cleanly (e.g. it contains an
+// unrecognized token). This allows callers to avoid overwriting the original
+// file with malformed output (see issue #34).
+func TestProcessFileReturnsErrorOnInvalidInput(t *testing.T) {
+	a := require.New(t)
+
+	invalidContent := "model Test\n  Real x = 1 # bad token;\nequation\n  x = 2;\nend Test;\n"
+	sourceFile := path.Join(outputDir, "invalid-input.mo")
+	a.NoError(os.WriteFile(sourceFile, []byte(invalidContent), 0644))
+	defer os.Remove(sourceFile)
+
+	var out bytes.Buffer
+	err := processFile(sourceFile, &out, Config{-1, false})
+
+	a.Error(err, "processFile should return an error for input with unrecognized tokens")
+}


### PR DESCRIPTION
## Summary

Fixes #34.

Previously, when `modelicafmt -w` encountered a `token recognition error` (or any other lexer/parser error), ANTLR's default console error listener only printed the error to stderr but still produced a truncated/incorrect parse tree. The formatter then wrote that malformed output back to the `.mo` file, corrupting it.

This change makes the formatter refuse to modify a file it can't parse cleanly.

## Changes

- **`modelicafmt.go`**: Added a `parseErrorListener` that collects lexer *and* parser syntax errors. It replaces ANTLR's default console error listeners on both the lexer and parser. `processFile` now returns an error (instead of always `nil`) when any errors were encountered.
- **`main.go`**: `processAndWriteFile` no longer panics on a parse error. Instead it reports the error to stderr, leaves the original file untouched, and the process exits with a non-zero status. When formatting a directory, valid files are still formatted while invalid files are skipped.
- **`modelicafmt_test.go`**: Added `TestProcessFileReturnsErrorOnInvalidInput` to lock in the behavior.

## Verification

- Existing formatting tests still pass; `go vet` and `gofmt` are clean.
- Manual check with a file containing an unrecognized token:

```
$ modelicafmt -w bad.mo
error: bad.mo: line 2:13 token recognition error at: '#'; line 2:15 missing ';' at 'bad'
skipping bad.mo (file left unchanged)
$ echo $?
1
```

The file is left byte-for-byte unchanged, and valid files continue to format and write correctly.