### PR TITLE
Add -wrap-arrays option for multidimensional array formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Add `-wrap-arrays` option to format multidimensional arrays (`{...}`) across
+  multiple lines outside of annotations (issue #29)
+
 # Version 0.1
 
 * Support formatting of Modelica files

--- a/README.md
+++ b/README.md
@@ -7,10 +7,37 @@ The Modelica Formatter provides the ability to automatically format Modelica cod
 ```bash
 modelica-fmt [-w] [-help] <sources>...
 Options:
-  -w  overwrite source with formatted output. If flag is not present print to stdout
+  -w            overwrite source with formatted output. If flag is not present print to stdout
+  -wrap-arrays  wrap multidimensional arrays ({...}) across multiple lines (outside annotations)
 Arguments:
   sources  one or more files or directories to format
 ```
+
+### Array formatting (`-wrap-arrays`)
+
+By default arrays (`{...}`) are kept on a single line. With `-wrap-arrays`,
+multidimensional arrays outside of annotations are broken across lines in a
+compact style: the innermost two dimensions are kept inline while the outer
+`max(N-2, 1)` dimension levels are broken. For example:
+
+```modelica
+parameter Integer array2D[2,2]={
+  {1,2},
+  {3,4}};
+parameter Integer array3D[2,2,2]={
+  {{1,2},{3,4}},
+  {{5,6},{7,8}}};
+parameter Integer array4D[2,2,2,2]={
+  {
+    {{1,2},{3,4}},
+    {{5,6},{7,8}}},
+  {
+    {{9,10},{11,12}},
+    {{13,14},{15,16}}}};
+```
+
+1D arrays, iterator constructors, matrices (`[...]`) and arrays inside
+annotations are left unchanged.
 
 To run the examples:
 

--- a/examples/example-arrays-nd-out.mo
+++ b/examples/example-arrays-nd-out.mo
@@ -1,0 +1,31 @@
+within Somewhere;
+model NdArrays
+  "Example demonstrating multidimensional array wrapping (-wrap-arrays)"
+  // 1D arrays stay on a single line
+  parameter Integer array1D[5]={1,2,3,4,5};
+  // 2D arrays break once (innermost dimension stays inline)
+  parameter Integer array2D[2,2]={
+    {1,2},
+    {3,4}};
+  // 3D arrays break once (innermost two dimensions stay inline)
+  parameter Integer array3D[2,2,2]={
+    {{1,2},{3,4}},
+    {{5,6},{7,8}}};
+  // 4D arrays break the two outer dimensions (innermost two stay inline)
+  parameter Integer array4D[2,2,2,2]={
+    {
+      {{1,2},{3,4}},
+      {{5,6},{7,8}}},
+    {
+      {{9,10},{11,12}},
+      {{13,14},{15,16}}}};
+  // iterator constructors are left untouched
+  parameter Integer iter[3]={i for i in 1:3};
+  // matrices keep their existing per-row formatting
+  parameter Real matrixA[2,3]=[
+    1.0,2.0,3.0;
+    5.0,6.0,7.0];
+  // arrays inside annotations remain on a single line
+  parameter Real p=1.0
+    annotation (Dialog(group="Fan"));
+end NdArrays;

--- a/examples/example-arrays-nd.mo
+++ b/examples/example-arrays-nd.mo
@@ -1,0 +1,26 @@
+within Somewhere;
+model NdArrays
+  "Example demonstrating multidimensional array wrapping (-wrap-arrays)"
+
+  // 1D arrays stay on a single line
+  parameter Integer array1D[5] = {1, 2, 3, 4, 5};
+
+  // 2D arrays break once (innermost dimension stays inline)
+  parameter Integer array2D[2,2] = {{1, 2}, {3, 4}};
+
+  // 3D arrays break once (innermost two dimensions stay inline)
+  parameter Integer array3D[2,2,2] = {{{1, 2}, {3, 4}}, {{5, 6}, {7, 8}}};
+
+  // 4D arrays break the two outer dimensions (innermost two stay inline)
+  parameter Integer array4D[2,2,2,2] = {{{{1, 2}, {3, 4}}, {{5, 6}, {7, 8}}}, {{{9, 10}, {11, 12}}, {{13, 14}, {15, 16}}}};
+
+  // iterator constructors are left untouched
+  parameter Integer iter[3] = {i for i in 1:3};
+
+  // matrices keep their existing per-row formatting
+  parameter Real matrixA[2,3] = [1.0, 2.0, 3.0; 5.0, 6.0, 7.0];
+
+  // arrays inside annotations remain on a single line
+  parameter Real p = 1.0 annotation (Dialog(group="Fan"));
+
+end NdArrays;

--- a/examples/example-arrays-wrapped-out.mo
+++ b/examples/example-arrays-wrapped-out.mo
@@ -1,0 +1,36 @@
+within Somewhere;
+class MyClass
+  "Class to demo formatting arrays and matrices"
+  extends Modelica.Icons.BasesPackage;
+  parameter Real var1=3.14;
+  parameter Real x[3];
+  parameter Real y[3]={1.0,0.0,-1.0};
+  parameter Real z[5]={1.0,0.0,-1.0,2.0,0.0};
+  parameter Real A[2,3]={
+    {1.0,2.0,3.0},
+    {5.0,6.0,7.0}};
+  parameter Real B[:,3]={
+    {1.0,2.0,3.0},
+    {5.0,6.0,7.0},
+    {1.0,2.0,3.0},
+    {5.0,6.0,7.0},
+    {1.0,2.0,3.0},
+    {5.0,6.0,7.0},
+    {1.0,2.0,3.0},
+    {5.0,6.0,7.0}};
+  parameter Real C[2,3]=[
+    1.0,2.0,3.0;
+    5.0,6.0,7.0];
+  parameter Integer D[4,3]=[
+    0,1,1;
+    2,3,5;
+    8,13,21;
+    34,55,89];
+  parameter Real fraPFan_nominal(
+    unit="W/(kg/s)")=275/0.15
+    "Fan power divided by water mass flow rate at design condition"
+    annotation (Dialog(group="Fan"));
+  parameter Modelica.SIunits.Power PFan_nominal=fraPFan_nominal*m_flow_nominal
+    "Fan power"
+    annotation (Dialog(group="Fan"));
+end MyClass;

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ var (
 	versionFlag   = flag.Bool("v", false, "display tool version")
 	emptyLineFlag = flag.Bool("extra-padding", false, "BETA: adds empty lines for padding")
 	lineLength    = flag.Int("line-length", -1, "how many characters allowed per line; -1 means no max")
+	wrapArrays    = flag.Bool("wrap-arrays", false, "wrap multidimensional arrays ({...}) across multiple lines (outside annotations)")
 	// hadError is set to true when a file could not be processed, so the
 	// program can exit with a non-zero status without aborting other files
 	hadError bool
@@ -42,7 +43,7 @@ func isModelicaFile(f os.FileInfo) bool {
 
 func processAndWriteFile(filename string) {
 	var b bytes.Buffer
-	err := processFile(filename, bufio.NewWriter(&b), Config{*lineLength, *emptyLineFlag})
+	err := processFile(filename, bufio.NewWriter(&b), Config{*lineLength, *emptyLineFlag, *wrapArrays})
 	if err != nil {
 		// The file could not be parsed cleanly (e.g. it contains an
 		// unrecognized token). Leave the original file untouched and report

--- a/modelicafmt.go
+++ b/modelicafmt.go
@@ -17,6 +17,11 @@ import (
 type Config struct {
 	maxLineLength int
 	emptyLines    bool
+	// wrapArrays, when true, breaks multidimensional arrays (`{...}`) across
+	// multiple lines outside of annotations. The innermost two dimensions are
+	// kept inline; the outer `max(N-2, 1)` dimension levels are broken. See
+	// issue #29.
+	wrapArrays bool
 }
 
 const (
@@ -46,21 +51,28 @@ func (l *modelicaListener) insertIndentBefore(rule antlr.ParserRuleContext) bool
 		parser.INamed_argumentContext:
 		return 0 == l.inAnnotation || 0 < l.inModelAnnotation
 	case parser.IExpressionContext:
-		if len(l.modelAnnotationVectorStack) == 0 {
-			return false
+		if len(l.modelAnnotationVectorStack) > 0 {
+			// handle expression which is an element of a vector (array_arguments) and within model annotation
+			arrayArgumentsNode, ok := rule.GetParent().(*parser.Array_argumentsContext)
+			if !ok {
+				return false
+			}
+
+			// check if the vector is the same as the one on top of our stack
+			thisVectorInterval := arrayArgumentsNode.GetParent().(*parser.VectorContext).GetSourceInterval()
+			stackVectorInterval := l.modelAnnotationVectorStack[len(l.modelAnnotationVectorStack)-1].GetSourceInterval()
+			return thisVectorInterval.Start == stackVectorInterval.Start && thisVectorInterval.Stop == stackVectorInterval.Stop
 		}
 
-		// handle expression which is an element of a vector (array_arguments) and within model annotation
-		arrayArgumentsNode, ok := rule.GetParent().(*parser.Array_argumentsContext)
-		if !ok {
-			return false
-		}
-
-		// check if the vector is the same as the one on top of our stack
-		thisVectorInterval := arrayArgumentsNode.GetParent().(*parser.VectorContext).GetSourceInterval()
-		stackVectorInterval := l.modelAnnotationVectorStack[len(l.modelAnnotationVectorStack)-1].GetSourceInterval()
-		if thisVectorInterval.Start == stackVectorInterval.Start && thisVectorInterval.Stop == stackVectorInterval.Stop {
-			return true
+		// handle expression which is a direct element of a multidimensional array
+		// that should be wrapped across lines (see issue #29). This only applies
+		// outside of annotations, where arrays are kept on a single line.
+		if l.config.wrapArrays && l.inAnnotation == 0 {
+			if arrayArgumentsNode, ok := rule.GetParent().(*parser.Array_argumentsContext); ok {
+				if vectorNode, ok := arrayArgumentsNode.GetParent().(*parser.VectorContext); ok {
+					return l.wrapVectors[vectorNode]
+				}
+			}
 		}
 		return false
 	case parser.IFunction_argumentContext:
@@ -196,6 +208,13 @@ type modelicaListener struct {
 	// should be indented or not by checking if the top of the stack is its ancestor
 	modelAnnotationVectorStack []antlr.RuleContext
 
+	// wrapVectors is the set of `vector` contexts whose direct elements should
+	// be broken onto their own indented lines. It is populated when entering the
+	// outermost vector of a multidimensional array (outside annotations) if the
+	// wrapArrays config option is enabled, and cleared when that outermost vector
+	// is exited. See issue #29 and shouldWrapVector.
+	wrapVectors map[*parser.VectorContext]bool
+
 	// NOTE: consider refactoring this simple approach for context awareness with
 	// a set.
 	// It should probably be map[string]int for rule name and current count (rules can be recursive, ie inside the same rule multiple times)
@@ -226,6 +245,7 @@ func newListener(out io.Writer, commentTokens []antlr.Token, config Config) *mod
 		previousTokenIdx:     -1,
 		commentTokens:        commentTokens,
 		currentLineLength:    0,
+		wrapVectors:          map[*parser.VectorContext]bool{},
 		config:               config,
 	}
 }
@@ -438,7 +458,19 @@ func (l *modelicaListener) ExitModel_annotation(node *parser.Model_annotationCon
 }
 
 func (l *modelicaListener) EnterVector(node *parser.VectorContext) {
+	// Determine whether this is the outermost vector before incrementing the
+	// counter (an outermost array has no enclosing vector).
+	isOutermostVector := l.inVector == 0
 	l.inVector++
+
+	// When array wrapping is enabled and we're outside of an annotation, compute
+	// the set of vectors whose elements should be broken onto separate lines. We
+	// only do this once, at the outermost vector, and recurse over the whole
+	// array so that indentation state is available while walking its children.
+	if l.config.wrapArrays && l.inAnnotation == 0 && isOutermostVector {
+		l.markWrapVectors(node, true)
+	}
+
 	if l.inModelAnnotation > 0 {
 		// if this array uses an iterator for construction it gets no special treatment
 		if _, ok := node.GetChild(0).(*parser.Array_iterator_constructorContext); ok {
@@ -462,6 +494,12 @@ func (l *modelicaListener) EnterVector(node *parser.VectorContext) {
 
 func (l *modelicaListener) ExitVector(node *parser.VectorContext) {
 	l.inVector--
+
+	// clear the wrap set once we've exited the outermost vector
+	if l.inVector == 0 && len(l.wrapVectors) > 0 {
+		l.wrapVectors = map[*parser.VectorContext]bool{}
+	}
+
 	if len(l.modelAnnotationVectorStack) > 0 {
 		annotationVectorInterval := l.modelAnnotationVectorStack[len(l.modelAnnotationVectorStack)-1].GetSourceInterval()
 		thisVectorInterval := node.GetSourceInterval()
@@ -469,6 +507,76 @@ func (l *modelicaListener) ExitVector(node *parser.VectorContext) {
 			l.modelAnnotationVectorStack = l.modelAnnotationVectorStack[:len(l.modelAnnotationVectorStack)-1]
 		}
 	}
+}
+
+// expressionAsVector returns the VectorContext that an expression consists of,
+// if the expression is purely a vector literal (e.g. an element of a
+// multidimensional array like `{1, 2}` in `{{1, 2}, {3, 4}}`). It returns nil
+// if the expression is anything else (a scalar, an arithmetic expression, a
+// function call, etc). It works by descending the single-child expression chain
+// (expression -> ... -> primary -> vector); any node with more than one child
+// means the expression is not a bare vector.
+func expressionAsVector(node antlr.Tree) *parser.VectorContext {
+	for node != nil {
+		if vectorNode, ok := node.(*parser.VectorContext); ok {
+			return vectorNode
+		}
+		if node.GetChildCount() != 1 {
+			return nil
+		}
+		node = node.GetChild(0)
+	}
+	return nil
+}
+
+// directElementVectors returns the vectors which are direct elements of the
+// given vector (i.e. the sub-arrays of a multidimensional array). Elements which
+// are not bare vectors (scalars, expressions, iterator constructors, ...) are
+// skipped.
+func directElementVectors(node *parser.VectorContext) []*parser.VectorContext {
+	arrayArguments := node.Array_arguments()
+	if arrayArguments == nil {
+		return nil
+	}
+
+	var vectors []*parser.VectorContext
+	for _, child := range arrayArguments.GetChildren() {
+		expressionNode, ok := child.(*parser.ExpressionContext)
+		if !ok {
+			continue
+		}
+		if vectorNode := expressionAsVector(expressionNode); vectorNode != nil {
+			vectors = append(vectors, vectorNode)
+		}
+	}
+	return vectors
+}
+
+// markWrapVectors walks a multidimensional array and records, in l.wrapVectors,
+// which vectors should have their direct elements broken onto separate lines. It
+// returns the array nesting depth of the given vector (1 for a vector of
+// scalars, 2 for a vector of such vectors, etc).
+//
+// A vector's elements are wrapped when either:
+//   - its depth is >= 3 (there are more than two dimensions below it), or
+//   - its depth is 2 and it is the outermost array.
+//
+// This keeps the innermost two dimensions inline while breaking the outer
+// max(N-2, 1) dimension levels (see issue #29).
+func (l *modelicaListener) markWrapVectors(node *parser.VectorContext, isOutermost bool) int {
+	maxChildDepth := 0
+	for _, childVector := range directElementVectors(node) {
+		childDepth := l.markWrapVectors(childVector, false)
+		if childDepth > maxChildDepth {
+			maxChildDepth = childDepth
+		}
+	}
+
+	depth := maxChildDepth + 1
+	if depth >= 3 || (depth == 2 && isOutermost) {
+		l.wrapVectors[node] = true
+	}
+	return depth
 }
 
 func (l *modelicaListener) EnterNamed_argument(node *parser.Named_argumentContext) {

--- a/modelicafmt_test.go
+++ b/modelicafmt_test.go
@@ -32,13 +32,15 @@ var exampleFileTests = []struct {
 	outFile         string
 	formatterConfig Config
 }{
-	{"gmt-coolingtower.mo", "gmt-coolingtower-out.mo", Config{-1, false}},
-	{"functions.mo", "functions-out.mo", Config{-1, false}},
-	{"example-no-within.mo", "example-no-within-out.mo", Config{-1, false}},
-	{"example-arrays.mo", "example-arrays-out.mo", Config{-1, false}},
-	{"gmt-building.mo", "gmt-building-out.mo", Config{-1, false}},
-	{"gmt-building.mo", "gmt-building-80-out.mo", Config{80, false}},
-	{"gmt-building.mo", "gmt-building-empty-lines-out.mo", Config{-1, true}},
+	{"gmt-coolingtower.mo", "gmt-coolingtower-out.mo", Config{-1, false, false}},
+	{"functions.mo", "functions-out.mo", Config{-1, false, false}},
+	{"example-no-within.mo", "example-no-within-out.mo", Config{-1, false, false}},
+	{"example-arrays.mo", "example-arrays-out.mo", Config{-1, false, false}},
+	{"example-arrays.mo", "example-arrays-wrapped-out.mo", Config{-1, false, true}},
+	{"example-arrays-nd.mo", "example-arrays-nd-out.mo", Config{-1, false, true}},
+	{"gmt-building.mo", "gmt-building-out.mo", Config{-1, false, false}},
+	{"gmt-building.mo", "gmt-building-80-out.mo", Config{80, false, false}},
+	{"gmt-building.mo", "gmt-building-empty-lines-out.mo", Config{-1, true, false}},
 }
 
 func TestFormattingExamples(t *testing.T) {
@@ -82,7 +84,7 @@ func TestProcessFileReturnsErrorOnInvalidInput(t *testing.T) {
 	defer os.Remove(sourceFile)
 
 	var out bytes.Buffer
-	err := processFile(sourceFile, &out, Config{-1, false})
+	err := processFile(sourceFile, &out, Config{-1, false, false})
 
 	a.Error(err, "processFile should return an error for input with unrecognized tokens")
 }


### PR DESCRIPTION
## Summary

Implements the compact multidimensional array layout requested in #29 (specifically @mwetter's preferred style). Arrays (`{...}`) are currently always collapsed onto a single line, which produces unreadable walls for higher-dimensional arrays, while matrices (`[...]`) always break per row. This PR adds an **opt-in** `-wrap-arrays` flag to break multidimensional arrays across lines.

Default behavior is unchanged — this only affects output when `-wrap-arrays` is passed.

## Formatting rule

Keeps the **innermost two dimensions inline** and breaks the outer `max(N-2, 1)` dimension levels. This stays true to mwetter's "compact, see lots of code" preference while still breaking 2D arrays:

```modelica
parameter Integer array2D[2,2]={
  {1,2},
  {3,4}};

parameter Integer array3D[2,2,2]={
  {{1,2},{3,4}},
  {{5,6},{7,8}}};

parameter Integer array4D[2,2,2,2]={
  {
    {{1,2},{3,4}},
    {{5,6},{7,8}}},
  {
    {{9,10},{11,12}},
    {{13,14},{15,16}}}};
```

Left unchanged: 1D arrays, iterator constructors (`{i for i in 1:3}`), matrices (`[...]`), and arrays inside annotations (which stay on one line, as before). Existing tight spacing around `=` and `,` is preserved.

## Implementation

- New `wrapArrays` field on `Config`, wired to the `-wrap-arrays` CLI flag.
- On entering the outermost `vector`, a recursive depth walk (`markWrapVectors`) records which vectors should have their elements broken onto their own indented lines; `insertIndentBefore` consults that set for element expressions. This reuses the existing indentation plumbing already used for model-annotation vectors.
- Annotations are excluded via the existing `inAnnotation` tracking, so annotation arrays are untouched.

## Testing

- New example fixtures: `examples/example-arrays-nd.mo` (covers 1D/2D/3D/4D, iterator constructor, matrix, annotation) plus expected outputs, and a wrapped variant of the existing `example-arrays.mo`.
- All existing tests pass; output verified idempotent and to combine gracefully with `-line-length`.
- `go build ./...` and `gofmt` clean.

## Notes for reviewers

- The exact layout (dubbed "Interpretation 1") reconciles Option B with 2D arrays also breaking. @mwetter / @trivvz — please confirm the layout matches what you had in mind.
- README documents the new flag; the previously-undocumented flags (`-v`, `-extra-padding`, `-line-length`) were left as-is to keep this PR focused.

Closes #29