### PR TITLE
Tweak formatter output for readability (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Unreleased
 
+* Tweak default formatting for readability (issue #26):
+  * Keep a function call with a single argument on one line instead of breaking
+    the argument onto its own line, e.g. `pre(x)`, `der(y)`, `sin(z)`,
+    `sum(a .* b)`. Calls with two or more arguments are unchanged.
+  * Insert a blank line before `equation`/`initial equation`,
+    `algorithm`/`initial algorithm`, and `public`/`protected` section headers to
+    separate them from the preceding declarations. The blank line is not
+    duplicated when `-extra-padding` already adds one.
+  * Collapse the stray empty line often left between the final `</ul>` and
+    `</html>` of a `revisions` docstring (`</ul>\n\n</html>` becomes
+    `</ul>\n</html>`).
 * Add native support for formatting templated Modelica (`.mot`/`.mopt`) files that embed Jinja
   constructs (`{{ ... }}`, `{% ... %}`, `{% raw %}`), ported from geojson-modelica-translator's
   `format_modelica_files.py`. `.mot` and `.mopt` files are detected automatically (including in directory

--- a/README.md
+++ b/README.md
@@ -33,8 +33,24 @@ For example, to overwrite a file in place while wrapping lines at 80 characters:
 modelica-fmt -w -line-length 80 internal/format/testdata/gmt-building.mo
 ```
 
-### Array formatting (`-wrap-arrays`)
+### Default formatting behavior
 
+The formatter always applies the following readability rules (no flag required):
+
+- **Single-argument calls stay on one line.** A function call with exactly one
+  argument keeps its argument inline instead of breaking it onto its own line,
+  so common wrappers such as `pre(x)`, `der(y)`, `sin(z)` and `sum(a .* b)`
+  remain compact. Calls with two or more arguments are broken as before.
+- **Blank line before section headers.** A single blank line is inserted before
+  `equation`/`initial equation`, `algorithm`/`initial algorithm`, and
+  `public`/`protected` section headers to separate them from the preceding
+  declarations. When `-extra-padding` already adds a blank line there, it is not
+  duplicated.
+- **Tidy revision docstrings.** The stray empty line often left between the final
+  `</ul>` and `</html>` of a `revisions` docstring is removed
+  (`</ul>\n\n</html>` becomes `</ul>\n</html>`).
+
+### Array formatting (`-wrap-arrays`)
 By default arrays (`{...}`) are kept on a single line. With `-wrap-arrays`,
 multidimensional arrays outside of annotations are broken across lines in a
 compact style: the innermost two dimensions are kept inline while the outer

--- a/internal/format/htmlformat.go
+++ b/internal/format/htmlformat.go
@@ -6,10 +6,26 @@ package format
 import (
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
 	"golang.org/x/net/html"
 )
+
+// revisionListBlankLineRe matches the stray blank line(s) that are commonly left
+// between the closing `</ul>` of a revisions list and the closing `</html>` of a
+// Modelica annotation docstring. The trailing indentation before `</html>` is
+// captured so it can be preserved. HTML tag names are matched case-insensitively.
+var revisionListBlankLineRe = regexp.MustCompile(`(?i)(</ul>)[ \t]*\r?\n(?:[ \t]*\r?\n)+([ \t]*)(</html>)`)
+
+// collapseRevisionListBlankLine removes the extra empty line(s) frequently left
+// between the final `</ul>` and `</html>` of a revisions docstring, turning
+// `</ul>\n\n</html>` into `</ul>\n</html>` (see issue #26). Content other than
+// that blank-line run is left untouched (including the original tag casing and
+// the indentation preceding `</html>`).
+func collapseRevisionListBlankLine(s string) string {
+	return revisionListBlankLineRe.ReplaceAllString(s, "${1}\n${2}${3}")
+}
 
 // voidElements are HTML elements that never have content or an end tag.
 var voidElements = map[string]bool{

--- a/internal/format/htmlformat_test.go
+++ b/internal/format/htmlformat_test.go
@@ -41,8 +41,31 @@ func TestIsHTMLContent(t *testing.T) {
 	a.False(isHTMLContent(""))
 }
 
+func TestCollapseRevisionListBlankLine(t *testing.T) {
+	a := require.New(t)
+
+	// a single blank line between </ul> and </html> is removed
+	a.Equal("</ul>\n</html>", collapseRevisionListBlankLine("</ul>\n\n</html>"))
+
+	// multiple blank lines (including whitespace-only lines) collapse to one newline
+	a.Equal("</ul>\n</html>", collapseRevisionListBlankLine("</ul>\n\n  \n\n</html>"))
+
+	// indentation before </html> is preserved
+	a.Equal("</ul>\n  </html>", collapseRevisionListBlankLine("</ul>\n\n  </html>"))
+
+	// tag names are matched case-insensitively
+	a.Equal("</UL>\n</HTML>", collapseRevisionListBlankLine("</UL>\n\n</HTML>"))
+
+	// already-correct content is left untouched
+	a.Equal("</ul>\n</html>", collapseRevisionListBlankLine("</ul>\n</html>"))
+
+	// unrelated content is left untouched
+	a.Equal("<p>text</p>\n\n<p>more</p>", collapseRevisionListBlankLine("<p>text</p>\n\n<p>more</p>"))
+}
+
 func TestFormatHTMLDocStringBasic(t *testing.T) {
 	a := require.New(t)
+
 	out, err := formatHTMLDocString("<html><p>hi</p></html>", 0)
 	a.NoError(err)
 	a.Equal("<html>\n  <p>hi</p>\n</html>", out)

--- a/internal/format/modelicafmt.go
+++ b/internal/format/modelicafmt.go
@@ -56,9 +56,12 @@ func (l *modelicaListener) insertIndentBefore(rule antlr.ParserRuleContext) bool
 		parser.IExpression_listContext,
 		parser.IConstraining_clauseContext,
 		parser.IIf_expressionContext,
-		parser.IIf_expression_bodyContext,
-		parser.IExternal_function_call_argumentContext:
+		parser.IIf_expression_bodyContext:
 		return true
+	case parser.IExternal_function_call_argumentContext:
+		// keep a lone external function call argument on the same line as the
+		// call, e.g. `EnergyPlusInputVariableFree(input2)` (issue #26)
+		return !isSoleExternalFunctionCallArgument(rule)
 	case parser.IString_commentContext:
 		return 0 == l.inAnnotation
 	case
@@ -91,10 +94,59 @@ func (l *modelicaListener) insertIndentBefore(rule antlr.ParserRuleContext) bool
 		}
 		return false
 	case parser.IFunction_argumentContext:
-		return 0 == l.inNamedArgument && 0 == l.inVector && (0 == l.inAnnotation || 0 < l.inModelAnnotation)
+		if 0 != l.inNamedArgument || 0 != l.inVector || (0 != l.inAnnotation && 0 == l.inModelAnnotation) {
+			return false
+		}
+		// keep a lone function argument on the same line as the call, e.g.
+		// `pre(x)`, `der(y)`, `sin(z)` (issue #26)
+		return !isSoleFunctionArgument(rule)
 	default:
 		return false
 	}
+}
+
+// isSoleFunctionArgument reports whether the given function_argument is the only
+// argument of its function call, i.e. the call looks like `f(x)`. Such calls are
+// kept on a single line rather than breaking the argument onto its own line (see
+// issue #26). Only positional arguments directly under a function_call_args are
+// considered; arguments in a comma-separated list or an array constructor (`for`)
+// are not sole arguments.
+//
+// The grammar is left-recursive:
+//
+//	function_call_args : '(' (function_arguments)? ')' ;
+//	function_arguments : function_argument (',' function_arguments | 'for' for_indices)? | named_arguments ;
+//
+// so a single positional argument produces a function_arguments node with a lone
+// function_argument child whose parent's parent is the function_call_args.
+func isSoleFunctionArgument(rule antlr.ParserRuleContext) bool {
+	args, ok := rule.GetParent().(*parser.Function_argumentsContext)
+	if !ok {
+		return false
+	}
+	if _, ok := args.GetParent().(*parser.Function_call_argsContext); !ok {
+		return false
+	}
+	// a comma-separated list or a `for` constructor adds sibling children, so a
+	// sole argument is the only child of the top-level function_arguments node
+	return args.GetChildCount() == 1
+}
+
+// isSoleExternalFunctionCallArgument reports whether the given
+// external_function_call_argument is the only argument of its external function
+// call, e.g. `EnergyPlusInputVariableFree(input2)`. Such calls are kept on a
+// single line rather than breaking the argument onto its own line (see issue
+// #26).
+//
+//	external_function_call_args : external_function_call_argument (',' external_function_call_argument)* ;
+//
+// so a single argument is the only child of the external_function_call_args node.
+func isSoleExternalFunctionCallArgument(rule antlr.ParserRuleContext) bool {
+	args, ok := rule.GetParent().(*parser.External_function_call_argsContext)
+	if !ok {
+		return false
+	}
+	return args.GetChildCount() == 1
 }
 
 // insertSpaceBeforeToken returns true if a space should be inserted before the current token
@@ -194,6 +246,11 @@ type modelicaListener struct {
 	commentTokens                []antlr.Token // stores comments to insert while writing
 	maxLineLength                int           // configuration for num charaters per line
 	currentLineLength            int           // length of the line up to the writing position
+	// trailingNewlines counts the number of consecutive newline characters most
+	// recently written (reset whenever non-newline content is written). It lets
+	// ensureBlankLineBefore add a blank line before a section header without
+	// doubling an existing blank line (e.g. one added by -extra-padding).
+	trailingNewlines int
 
 	// modelAnnotationVectorStack is a stack which stores `vector` contexts,
 	// which is used for conditionally indenting vector children
@@ -350,6 +407,17 @@ func (l *modelicaListener) writeString(str string) {
 		charsOnLastLine = len(str) - (lastNewlineIndex + 1)
 	}
 	l.currentLineLength += charsOnLastLine
+	l.trailingNewlines = countTrailingNewlines(str)
+}
+
+// countTrailingNewlines returns the number of consecutive '\n' characters at the
+// end of s.
+func countTrailingNewlines(s string) int {
+	n := 0
+	for i := len(s) - 1; i >= 0 && s[i] == '\n'; i-- {
+		n++
+	}
+	return n
 }
 
 // writeHTMLString writes a pre-formatted, multi-line HTML string literal. Unlike
@@ -365,6 +433,7 @@ func (l *modelicaListener) writeHTMLString(formatted string) {
 	} else {
 		l.currentLineLength = len(formatted) - (lastNewlineIndex + 1)
 	}
+	l.trailingNewlines = countTrailingNewlines(formatted)
 }
 
 func (l *modelicaListener) writeNewline() {
@@ -372,9 +441,24 @@ func (l *modelicaListener) writeNewline() {
 	l.writer.WriteString("\n")
 	l.onNewLine = true
 	l.currentLineLength = 0
+	l.trailingNewlines++
 
 	// WARNING: this is coupled with maybeIndent, which uses this state
 	l.lineIndentIncreased = false
+}
+
+// ensureBlankLineBefore guarantees that the next content is preceded by exactly
+// one blank line, without adding a second blank line when one is already present
+// (e.g. one inserted by -extra-padding). It is used to visually separate section
+// headers (equation/algorithm/public/protected) from the preceding content (see
+// issue #26).
+func (l *modelicaListener) ensureBlankLineBefore() {
+	if !l.onNewLine {
+		l.writeNewline()
+	}
+	for l.trailingNewlines < 2 {
+		l.writeNewline()
+	}
 }
 
 func (l *modelicaListener) writeComment(comment antlr.Token) {
@@ -432,19 +516,33 @@ func (l *modelicaListener) VisitTerminal(node antlr.TerminalNode) {
 		l.writeComment(commentToken)
 	}
 
-	if l.config.formatHTML && node.GetSymbol().GetTokenType() == parser.ModelicaLexerSTRING {
-		formatted, ok, err := maybeFormatHTMLString(node.GetText(), l.indentation()+1)
-		if err != nil {
-			// The string is an HTML docstring (starts with <html>) but could not
-			// be formatted because it is malformed/unbalanced. Record a clear
-			// error so processFile fails loudly rather than silently emitting the
-			// HTML unformatted, and leave the original token unchanged.
-			l.htmlErrors = append(l.htmlErrors, err.Error())
-		}
-		if ok {
-			l.writeHTMLString(formatted)
+	// insert a blank line before a `public`/`protected` section header so it is
+	// visually separated from the preceding content (issue #26). These keywords
+	// only appear as section markers in a class body.
+	if text := node.GetText(); text == "public" || text == "protected" {
+		l.ensureBlankLineBefore()
+	}
+
+	if node.GetSymbol().GetTokenType() == parser.ModelicaLexerSTRING {
+		if l.config.formatHTML {
+			formatted, ok, err := maybeFormatHTMLString(node.GetText(), l.indentation()+1)
+			if err != nil {
+				// The string is an HTML docstring (starts with <html>) but could not
+				// be formatted because it is malformed/unbalanced. Record a clear
+				// error so processFile fails loudly rather than silently emitting the
+				// HTML unformatted, and leave the original token unchanged.
+				l.htmlErrors = append(l.htmlErrors, err.Error())
+			}
+			if ok {
+				l.writeHTMLString(formatted)
+			} else {
+				l.writeString(node.GetText())
+			}
 		} else {
-			l.writeString(node.GetText())
+			// even without HTML pretty-printing, collapse the stray blank line
+			// often left between the last `</ul>` and `</html>` of a revisions
+			// docstring (issue #26)
+			l.writeString(collapseRevisionListBlankLine(node.GetText()))
 		}
 	} else {
 		l.writeString(node.GetText())
@@ -491,6 +589,17 @@ func (l *modelicaListener) ExitEveryRule(node antlr.ParserRuleContext) {
 	if l.insertIndentBefore(node) {
 		l.maybeDedent()
 	}
+}
+
+// EnterEquation_section and EnterAlgorithm_section insert a blank line before an
+// `equation`/`initial equation`/`algorithm`/`initial algorithm` section so it is
+// visually separated from the preceding declarations (issue #26).
+func (l *modelicaListener) EnterEquation_section(node *parser.Equation_sectionContext) {
+	l.ensureBlankLineBefore()
+}
+
+func (l *modelicaListener) EnterAlgorithm_section(node *parser.Algorithm_sectionContext) {
+	l.ensureBlankLineBefore()
 }
 
 func (l *modelicaListener) EnterAnnotation(node *parser.AnnotationContext) {

--- a/internal/format/modelicafmt_test.go
+++ b/internal/format/modelicafmt_test.go
@@ -34,6 +34,7 @@ var exampleFileTests = []struct {
 }{
 	{"gmt-coolingtower.mo", "gmt-coolingtower-out.mo", Config{-1, false, false, false}},
 	{"functions.mo", "functions-out.mo", Config{-1, false, false, false}},
+	{"tweaks.mo", "tweaks-out.mo", Config{-1, false, false, false}},
 	{"example-no-within.mo", "example-no-within-out.mo", Config{-1, false, false, false}},
 	{"example-arrays.mo", "example-arrays-out.mo", Config{-1, false, false, false}},
 	{"example-arrays.mo", "example-arrays-wrapped-out.mo", Config{-1, false, true, false}},

--- a/internal/format/testdata/example-no-within-out.mo
+++ b/internal/format/testdata/example-no-within-out.mo
@@ -16,7 +16,6 @@ class MyClass
     "Some comment"
     extends Modelica.Icons.Function;
     input Integer input2;
-  external "C" EnergyPlusInputVariableFree(
-    input2);
+  external "C" EnergyPlusInputVariableFree(input2);
   end destructor;
 end MyClass;

--- a/internal/format/testdata/functions-out.mo
+++ b/internal/format/testdata/functions-out.mo
@@ -17,7 +17,6 @@ class MyClass
     "Some comment"
     extends Modelica.Icons.Function;
     input Integer input2;
-  external "C" EnergyPlusInputVariableFree(
-    input2);
+  external "C" EnergyPlusInputVariableFree(input2);
   end destructor;
 end MyClass;

--- a/internal/format/testdata/gmt-building-80-out.mo
+++ b/internal/format/testdata/gmt-building-80-out.mo
@@ -68,8 +68,7 @@ model building
     annotation (Placement(transformation(extent={{-200,-60},{-180,-40}})));
   Buildings.Applications.DHC.Loads.BaseClasses.FlowDistribution disFloHea(
     redeclare package Medium=MediumW,
-    m_flow_nominal=sum(
-      terUni.mHeaWat_flow_nominal .* terUni.facSca),
+    m_flow_nominal=sum(terUni.mHeaWat_flow_nominal .* terUni.facSca),
     dp_nominal(
       displayUnit="Pa")=100000,
     have_pum=have_pum,
@@ -79,8 +78,7 @@ model building
     annotation (Placement(transformation(extent={{-140,-100},{-120,-80}})));
   Buildings.Applications.DHC.Loads.BaseClasses.FlowDistribution disFloCoo(
     redeclare package Medium=MediumW,
-    m_flow_nominal=sum(
-      terUni.mChiWat_flow_nominal .* terUni.facSca),
+    m_flow_nominal=sum(terUni.mChiWat_flow_nominal .* terUni.facSca),
     typDis=Buildings.Applications.DHC.Loads.Types.DistributionType.ChilledWater,
     dp_nominal(
       displayUnit="Pa")=100000,
@@ -89,6 +87,7 @@ model building
     nPorts_b1=nZon)
     "Chilled water distribution system"
     annotation (Placement(transformation(extent={{-140,-160},{-120,-140}})));
+
 equation
   connect(disFloHea.port_b,secHeaRet[1])
     annotation (Line(points={{140,-70},{240,-70},{240,32},{300,32}},color={0,127,

--- a/internal/format/testdata/gmt-building-empty-lines-out.mo
+++ b/internal/format/testdata/gmt-building-empty-lines-out.mo
@@ -84,8 +84,7 @@ model building
 
   Buildings.Applications.DHC.Loads.BaseClasses.FlowDistribution disFloHea(
     redeclare package Medium=MediumW,
-    m_flow_nominal=sum(
-      terUni.mHeaWat_flow_nominal .* terUni.facSca),
+    m_flow_nominal=sum(terUni.mHeaWat_flow_nominal .* terUni.facSca),
     dp_nominal(
       displayUnit="Pa")=100000,
     have_pum=have_pum,
@@ -96,8 +95,7 @@ model building
 
   Buildings.Applications.DHC.Loads.BaseClasses.FlowDistribution disFloCoo(
     redeclare package Medium=MediumW,
-    m_flow_nominal=sum(
-      terUni.mChiWat_flow_nominal .* terUni.facSca),
+    m_flow_nominal=sum(terUni.mChiWat_flow_nominal .* terUni.facSca),
     typDis=Buildings.Applications.DHC.Loads.Types.DistributionType.ChilledWater,
     dp_nominal(
       displayUnit="Pa")=100000,

--- a/internal/format/testdata/gmt-building-html-out.mo
+++ b/internal/format/testdata/gmt-building-html-out.mo
@@ -68,8 +68,7 @@ model building
     annotation (Placement(transformation(extent={{-200,-60},{-180,-40}})));
   Buildings.Applications.DHC.Loads.BaseClasses.FlowDistribution disFloHea(
     redeclare package Medium=MediumW,
-    m_flow_nominal=sum(
-      terUni.mHeaWat_flow_nominal .* terUni.facSca),
+    m_flow_nominal=sum(terUni.mHeaWat_flow_nominal .* terUni.facSca),
     dp_nominal(
       displayUnit="Pa")=100000,
     have_pum=have_pum,
@@ -79,8 +78,7 @@ model building
     annotation (Placement(transformation(extent={{-140,-100},{-120,-80}})));
   Buildings.Applications.DHC.Loads.BaseClasses.FlowDistribution disFloCoo(
     redeclare package Medium=MediumW,
-    m_flow_nominal=sum(
-      terUni.mChiWat_flow_nominal .* terUni.facSca),
+    m_flow_nominal=sum(terUni.mChiWat_flow_nominal .* terUni.facSca),
     typDis=Buildings.Applications.DHC.Loads.Types.DistributionType.ChilledWater,
     dp_nominal(
       displayUnit="Pa")=100000,
@@ -89,6 +87,7 @@ model building
     nPorts_b1=nZon)
     "Chilled water distribution system"
     annotation (Placement(transformation(extent={{-140,-160},{-120,-140}})));
+
 equation
   connect(disFloHea.port_b,secHeaRet[1])
     annotation (Line(points={{140,-70},{240,-70},{240,32},{300,32}},color={0,127,255}));

--- a/internal/format/testdata/gmt-building-out.mo
+++ b/internal/format/testdata/gmt-building-out.mo
@@ -68,8 +68,7 @@ model building
     annotation (Placement(transformation(extent={{-200,-60},{-180,-40}})));
   Buildings.Applications.DHC.Loads.BaseClasses.FlowDistribution disFloHea(
     redeclare package Medium=MediumW,
-    m_flow_nominal=sum(
-      terUni.mHeaWat_flow_nominal .* terUni.facSca),
+    m_flow_nominal=sum(terUni.mHeaWat_flow_nominal .* terUni.facSca),
     dp_nominal(
       displayUnit="Pa")=100000,
     have_pum=have_pum,
@@ -79,8 +78,7 @@ model building
     annotation (Placement(transformation(extent={{-140,-100},{-120,-80}})));
   Buildings.Applications.DHC.Loads.BaseClasses.FlowDistribution disFloCoo(
     redeclare package Medium=MediumW,
-    m_flow_nominal=sum(
-      terUni.mChiWat_flow_nominal .* terUni.facSca),
+    m_flow_nominal=sum(terUni.mChiWat_flow_nominal .* terUni.facSca),
     typDis=Buildings.Applications.DHC.Loads.Types.DistributionType.ChilledWater,
     dp_nominal(
       displayUnit="Pa")=100000,
@@ -89,6 +87,7 @@ model building
     nPorts_b1=nZon)
     "Chilled water distribution system"
     annotation (Placement(transformation(extent={{-140,-160},{-120,-140}})));
+
 equation
   connect(disFloHea.port_b,secHeaRet[1])
     annotation (Line(points={{140,-70},{240,-70},{240,32},{300,32}},color={0,127,255}));

--- a/internal/format/testdata/gmt-cooling-indirect-out.mot
+++ b/internal/format/testdata/gmt-cooling-indirect-out.mot
@@ -212,15 +212,16 @@ model {{ model_filename }}
     each k2=+1)
     "Temperatur difference on the district side"
     annotation (Placement(transformation(extent={{-60,106},{-40,126}})));
+
 protected
   final parameter Medium.ThermodynamicState sta_default=Medium.setState_pTX(
     T=Medium.T_default,
     p=Medium.p_default,
     X=Medium.X_default)
     "Medium state at default properties";
-  final parameter Modelica.Units.SI.SpecificHeatCapacity cp_default=Medium.specificHeatCapacityCp(
-    sta_default)
+  final parameter Modelica.Units.SI.SpecificHeatCapacity cp_default=Medium.specificHeatCapacityCp(sta_default)
     "Specific heat capacity of the fluid";
+
 {% endraw %}equation
   {% raw %} connect(hex.port_a2,port_a2)
     annotation (Line(points={{40,-6},{60,-6},{60,-60},{100,-60}},color={0,127,255}));

--- a/internal/format/testdata/gmt-coolingtower-out.mo
+++ b/internal/format/testdata/gmt-coolingtower-out.mo
@@ -83,6 +83,7 @@ model Merkel
     deltax=yMin/20)
     "Electric power consumed by fan"
     annotation (Placement(transformation(extent={{100,70},{120,90}}),iconTransformation(extent={{100,70},{120,90}})));
+
 protected
   final parameter Real fanRelPowDer[size(
     fanRelPow.r_V,
@@ -95,11 +96,10 @@ protected
     "Coefficients for fan relative power consumption as a function
     of control signal";
   Modelica.Blocks.Sources.RealExpression TWatIn(
-    final y=Medium.temperature(
-      Medium.setState_phX(
-        p=port_a.p,
-        h=inStream(port_a.h_outflow),
-        X=inStream(port_a.Xi_outflow))))
+    final y=Medium.temperature(Medium.setState_phX(
+      p=port_a.p,
+      h=inStream(port_a.h_outflow),
+      X=inStream(port_a.Xi_outflow))))
     "Water inlet temperature"
     annotation (Placement(transformation(extent={{-70,36},{-50,54}})));
   Modelica.Blocks.Sources.RealExpression mWat_flow(
@@ -118,6 +118,7 @@ protected
     final yMin=yMin)
     "Model for thermal performance"
     annotation (Placement(transformation(extent={{-20,40},{0,60}})));
+
 initial equation
   // Check validity of relative fan power consumption at y=yMin and y=1
   assert(
@@ -125,22 +126,20 @@ initial equation
       per=fanRelPow,
       r_V=yMin,
       d=fanRelPowDer) >-1E-4,
-    "The fan relative power consumption must be non-negative for y=0."+"\n   Obtained fanRelPow(0) = "+String(
-      cha.normalizedPower(
-        per=fanRelPow,
-        r_V=yMin,
-        d=fanRelPowDer))+"\n   You need to choose different values for the parameter fanRelPow.");
+    "The fan relative power consumption must be non-negative for y=0."+"\n   Obtained fanRelPow(0) = "+String(cha.normalizedPower(
+      per=fanRelPow,
+      r_V=yMin,
+      d=fanRelPowDer))+"\n   You need to choose different values for the parameter fanRelPow.");
   assert(
-    abs(
-      1-cha.normalizedPower(
-        per=fanRelPow,
-        r_V=1,
-        d=fanRelPowDer)) < 1E-4,
-    "The fan relative power consumption must be one for y=1."+"\n   Obtained fanRelPow(1) = "+String(
-      cha.normalizedPower(
-        per=fanRelPow,
-        r_V=1,
-        d=fanRelPowDer))+"\n   You need to choose different values for the parameter fanRelPow."+"\n   To increase the fan power, change fraPFan_nominal or PFan_nominal.");
+    abs(1-cha.normalizedPower(
+      per=fanRelPow,
+      r_V=1,
+      d=fanRelPowDer)) < 1E-4,
+    "The fan relative power consumption must be one for y=1."+"\n   Obtained fanRelPow(1) = "+String(cha.normalizedPower(
+      per=fanRelPow,
+      r_V=1,
+      d=fanRelPowDer))+"\n   You need to choose different values for the parameter fanRelPow."+"\n   To increase the fan power, change fraPFan_nominal or PFan_nominal.");
+
 equation
   connect(per.y,y)
     annotation (Line(points={{-22,58},{-40,58},{-40,80},{-120,80}},color={0,0,127}));

--- a/internal/format/testdata/gmt-design-data-series-out.mot
+++ b/internal/format/testdata/gmt-design-data-series-out.mot
@@ -38,8 +38,7 @@ record DesignDataSeries
     10,
     nBui)
     "Length of each connection pipe (supply only, not counting return line)";
-  parameter Modelica.Units.SI.Length lEnd=sum(
-    lDis)
+  parameter Modelica.Units.SI.Length lEnd=sum(lDis)
     "Length of the end of the distribution line (after last connection)";
   annotation (
     defaultComponentName="datDes",

--- a/internal/format/testdata/gmt-dhc-5g-wh-ghx-hpdirectcooling-variable-dist-out.mot
+++ b/internal/format/testdata/gmt-dhc-5g-wh-ghx-hpdirectcooling-variable-dist-out.mot
@@ -48,6 +48,7 @@ model district
     k=datDes.mSto_flow_nominal)
     "Scale with nominal mass flow rate for storage GHX pump"
     annotation (Placement(transformation(extent={{-240,-112},{-220,-92}})));
+
 equation
   connect(masFloDisPla.y,pla.mPum_flow)
     annotation (Line(points={{-229,20},{-184,20},{-184,4.66667},{-161.333,4.66667}},color={0,0,127}));

--- a/internal/format/testdata/gmt-hptrio-variable-dist-out.mot
+++ b/internal/format/testdata/gmt-hptrio-variable-dist-out.mot
@@ -49,6 +49,7 @@ model district
     k=datDes.mSto_flow_nominal)
     "Scale with nominal mass flow rate for storage GHX pump"
     annotation (Placement(transformation(extent={{-240,-112},{-220,-92}})));
+
 equation
   connect(masFloDisPla.y,pla.mPum_flow)
     annotation (Line(points={{-229,20},{-184,20},{-184,4.66667},{-161.333,4.66667}},color={0,0,127}));

--- a/internal/format/testdata/gmt-spawn-building-out.mot
+++ b/internal/format/testdata/gmt-spawn-building-out.mot
@@ -80,12 +80,9 @@ model building
     "Thermal zone"
     {% raw %} annotation (Placement(transformation(extent={{40,-20},{80,20}})));
   {% endraw %}{% endfor %}{% raw %}inner Buildings.ThermalZones.EnergyPlus_24_2_0.Building building(
-    idfName=Modelica.Utilities.Files.loadResource(
-      idfName),
-    epwName=Modelica.Utilities.Files.loadResource(
-      epwName),
-    weaName=Modelica.Utilities.Files.loadResource(
-      weaName))
+    idfName=Modelica.Utilities.Files.loadResource(idfName),
+    epwName=Modelica.Utilities.Files.loadResource(epwName),
+    weaName=Modelica.Utilities.Files.loadResource(weaName))
     "Building outer component"
     annotation (Placement(transformation(extent={{40,60},{60,80}})));
   Buildings.Controls.OBC.CDL.Reals.MultiSum mulSum(
@@ -115,8 +112,7 @@ model building
   Buildings.DHC.Loads.BaseClasses.FlowDistribution disFloHea(
     redeclare package Medium=MediumW,
     allowFlowReversal=true,
-    m_flow_nominal=sum(
-      terUni.mHeaWat_flow_nominal .* terUni.facMulZon),
+    m_flow_nominal=sum(terUni.mHeaWat_flow_nominal .* terUni.facMulZon),
     have_pum=have_pum,
     dp_nominal=100000,
     nPorts_a1=nZon,
@@ -126,8 +122,7 @@ model building
   Buildings.DHC.Loads.BaseClasses.FlowDistribution disFloCoo(
     redeclare package Medium=MediumW,
     allowFlowReversal=true,
-    m_flow_nominal=sum(
-      terUni.mChiWat_flow_nominal .* terUni.facMulZon),
+    m_flow_nominal=sum(terUni.mChiWat_flow_nominal .* terUni.facMulZon),
     typDis=Buildings.DHC.Loads.BaseClasses.Types.DistributionType.ChilledWater,
     dp_nominal=100000,
     have_pum=have_pum,
@@ -135,6 +130,7 @@ model building
     nPorts_b1=nZon)
     "Chilled water distribution system"
     annotation (Placement(transformation(extent={{-160,-230},{-140,-210}})));
+
 {% endraw %}equation
   {% raw %} connect(qRadGai_flow.y,multiplex3_1.u1[1])
     annotation (Line(points={{-45,178},{-26,178},{-26,145},{-22,145}},color={0,0,127},smooth=Smooth.None));

--- a/internal/format/testdata/gmt-time-series-building-out.mot
+++ b/internal/format/testdata/gmt-time-series-building-out.mot
@@ -79,19 +79,16 @@ model TimeSeriesBuilding
   parameter Modelica.Units.SI.Time Ti(
     min=Modelica.Constants.small)=10
     "Time constant of integrator block";
-  parameter Modelica.Units.SI.MassFlowRate mChiWat_flow_nominal=abs(
-    QCoo_flow_nominal/cp_default/(T_aChiWat_nominal-T_bChiWat_nominal))
+  parameter Modelica.Units.SI.MassFlowRate mChiWat_flow_nominal=abs(QCoo_flow_nominal/cp_default/(T_aChiWat_nominal-T_bChiWat_nominal))
     "Chilled water mass flow rate at nominal conditions (all units)"
     annotation (Dialog(group="Nominal condition"));
-  parameter Modelica.Units.SI.MassFlowRate mHeaWat_flow_nominal=abs(
-    QHea_flow_nominal/cp_default/(T_aHeaWat_nominal-T_bHeaWat_nominal))
+  parameter Modelica.Units.SI.MassFlowRate mHeaWat_flow_nominal=abs(QHea_flow_nominal/cp_default/(T_aHeaWat_nominal-T_bHeaWat_nominal))
     "Heating water mass flow rate at nominal conditions (all units)"
     annotation (Dialog(group="Nominal condition"));
   Modelica.Blocks.Sources.CombiTimeTable loa(
     tableOnFile=true,
     tableName="tab1",
-    fileName=Modelica.Utilities.Files.loadResource(
-      filNam),
+    fileName=Modelica.Utilities.Files.loadResource(filNam),
     extrapolation=Modelica.Blocks.Types.Extrapolation.Periodic,
     y(
       each unit="W"),
@@ -233,19 +230,19 @@ model TimeSeriesBuilding
     k=facMul) if have_heaLoa
     "Scaling"
     annotation (Placement(transformation(extent={{270,-130},{290,-110}})));
+
 protected
   parameter Modelica.Units.SI.SpecificHeatCapacity cp_air=1005
     "Air specific heat capacity";
-  parameter Modelica.Units.SI.SpecificHeatCapacity cpHeaWat_nominal=Medium.specificHeatCapacityCp(
-    Medium.setState_pTX(
-      Medium.p_default,
-      T_aHeaWat_nominal))
+  parameter Modelica.Units.SI.SpecificHeatCapacity cpHeaWat_nominal=Medium.specificHeatCapacityCp(Medium.setState_pTX(
+    Medium.p_default,
+    T_aHeaWat_nominal))
     "Heating water specific heat capacity at nominal conditions";
-  parameter Modelica.Units.SI.SpecificHeatCapacity cpChiWat_nominal=Medium.specificHeatCapacityCp(
-    Medium.setState_pTX(
-      Medium.p_default,
-      T_aChiWat_nominal))
+  parameter Modelica.Units.SI.SpecificHeatCapacity cpChiWat_nominal=Medium.specificHeatCapacityCp(Medium.setState_pTX(
+    Medium.p_default,
+    T_aChiWat_nominal))
     "Chilled water specific heat capacity at nominal conditions";
+
 equation
   connect(terUniHea.port_bHeaWat,disFloHea.ports_a1[1])
     annotation (Line(points={{90,-32.3333},{90,-32},{146,-32},{146,-64},{140,-64}},color={0,127,255}));

--- a/internal/format/testdata/tweaks-out.mo
+++ b/internal/format/testdata/tweaks-out.mo
@@ -1,0 +1,36 @@
+model Tweaks
+  "Demonstrates issue #26 output tweaks"
+  parameter Real x=1;
+  Real y;
+  Real z;
+
+public
+  Real w;
+
+protected
+  Real p;
+
+initial equation
+  y=pre(x);
+
+equation
+  z=der(y);
+  p=sin(x)+atan2(
+    x,
+    y);
+
+initial algorithm
+  w := abs(x);
+
+algorithm
+  w := max(
+    x,
+    y);
+  annotation (
+    Documentation(
+      revisions="<html>
+<ul>
+<li>Initial version.</li>
+</ul>
+</html>"));
+end Tweaks;

--- a/internal/format/testdata/tweaks.mo
+++ b/internal/format/testdata/tweaks.mo
@@ -1,0 +1,26 @@
+model Tweaks "Demonstrates issue #26 output tweaks"
+  parameter Real x = 1;
+  Real y;
+  Real z;
+public
+  Real w;
+protected
+  Real p;
+initial equation
+  y = pre(x);
+equation
+  z = der(y);
+  p = sin(x) + atan2(x, y);
+initial algorithm
+  w := abs(x);
+algorithm
+  w := max(x, y);
+  annotation (
+    Documentation(
+      revisions="<html>
+<ul>
+<li>Initial version.</li>
+</ul>
+
+</html>"));
+end Tweaks;


### PR DESCRIPTION
Closes #26.

Implements the three formatting tweaks requested in the issue (ported from the [lbl-srg/modelica-buildings PR #2426](https://github.com/lbl-srg/modelica-buildings/pull/2426) post-processing script directly into the formatter, so they apply by default with no extra step):

### 1. Single-argument calls stay on one line
A function call with exactly one argument keeps its argument inline instead of breaking it onto its own line, so common wrappers like `pre(x)`, `der(y)`, `sin(z)` and `sum(a .* b)` stay compact. Calls with two or more arguments are unchanged. Handled at the AST level for both regular (`function_call_args`) and external (`external_function_call_args`) calls, so nested multi-argument calls still break correctly.

### 2. Blank line before section headers
A single blank line is inserted before `equation`/`initial equation`, `algorithm`/`initial algorithm`, and `public`/`protected` section headers to separate them from the preceding declarations. A `trailingNewlines` counter ensures the blank line is **not** duplicated when `-extra-padding` already added one.

### 3. Tidy revision docstrings
The stray empty line frequently left between the final `</ul>` and `</html>` of a `revisions` docstring is removed (`</ul>\n\n</html>` → `</ul>\n</html>`), preserving the original tag casing and `</html>` indentation.

### Example
```modelica
  Real p;

initial equation
  y=pre(x);

equation
  z=der(y);
  p=sin(x)+atan2(
    x,
    y);
```

### Tests / docs
- New `tweaks.mo` fixture + golden output exercising all three tweaks, added to the example-file test table.
- New unit test `TestCollapseRevisionListBlankLine` covering single/multiple blank lines, preserved indentation, case-insensitivity, and no-op cases.
- Regenerated the affected golden `.mo`/`.mot` files; every diff is an intended single-arg collapse or section blank line.
- Updated `README.md` (new "Default formatting behavior" section) and `CHANGELOG.md`.

`make all` (build + test) passes.